### PR TITLE
fix: set page title to Ferrite Demo

### DIFF
--- a/ferrite-dashboard/Dioxus.toml
+++ b/ferrite-dashboard/Dioxus.toml
@@ -3,7 +3,7 @@ name = "ferrite-dashboard"
 default_platform = "web"
 
 [web.app]
-title = "Ferrite"
+title = "Ferrite Demo"
 
 [web.resource]
 style = []

--- a/ferrite-dashboard/index.html
+++ b/ferrite-dashboard/index.html
@@ -7,6 +7,7 @@
     <meta name="description" content="Firmware observability for ARM Cortex-M — crashes, metrics, and logs" />
     <link rel="icon" type="image/svg+xml" href="/assets/favicon.svg" />
     <link rel="manifest" href="/assets/manifest.json" />
+    <title>Ferrite Demo</title>
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>


### PR DESCRIPTION
Set explicit `<title>Ferrite Demo</title>` in index.html and update Dioxus.toml title.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>