### PR TITLE
fix: remove duplicate title, add admin device delete endpoint

### DIFF
--- a/examples/embassy-esp32c3/src/main.rs
+++ b/examples/embassy-esp32c3/src/main.rs
@@ -43,7 +43,7 @@ use ferrite_sdk::upload::UploadManager;
 
 const WIFI_SSID: &str = env!("WIFI_SSID");
 const WIFI_PASS: &str = env!("WIFI_PASS");
-const SERVER_PORT: u16 = 4000;
+const SERVER_PORT: u16 = 4001;
 const INGEST_PATH: &str = "/ingest/chunks";
 const INGEST_API_KEY: Option<&str> = option_env!("INGEST_API_KEY");
 const DEVICE_ID: &str = "esp32c3-embassy-01";

--- a/ferrite-dashboard/index.html
+++ b/ferrite-dashboard/index.html
@@ -7,7 +7,6 @@
     <meta name="description" content="Firmware observability for ARM Cortex-M — crashes, metrics, and logs" />
     <link rel="icon" type="image/svg+xml" href="/assets/favicon.svg" />
     <link rel="manifest" href="/assets/manifest.json" />
-    <title>Ferrite Demo</title>
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/ferrite-server/src/ingest.rs
+++ b/ferrite-server/src/ingest.rs
@@ -3,7 +3,7 @@ use axum::{
     extract::{DefaultBodyLimit, Path, State},
     http::StatusCode,
     response::IntoResponse,
-    routing::{get, post},
+    routing::{delete, get, post},
     Json, Router,
 };
 use serde::{Deserialize, Serialize};
@@ -1184,6 +1184,25 @@ async fn delete_device_handler(
     }
 }
 
+/// DELETE /admin/devices/:device_id — delete a device by its device_id string.
+async fn admin_delete_device_handler(
+    State(state): State<Arc<AppState>>,
+    Path(device_id): Path<String>,
+) -> impl IntoResponse {
+    let store = state.store.lock().await;
+    match store.delete_device_by_id(&device_id) {
+        Ok(true) => (StatusCode::OK, Json(serde_json::json!({ "ok": true }))),
+        Ok(false) => (
+            StatusCode::NOT_FOUND,
+            Json(serde_json::json!({ "error": "device not found" })),
+        ),
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({ "error": e.to_string() })),
+        ),
+    }
+}
+
 /// Pagination and time-range query parameters shared by list endpoints.
 #[derive(Debug, Deserialize)]
 struct ListParams {
@@ -1353,9 +1372,13 @@ pub fn router(state: Arc<AppState>) -> Router {
             "/ota/targets/:device_id",
             get(crate::ota::get_ota_target).delete(crate::ota::delete_ota_target),
         )
-        // Admin: backup & retention (#40, #29)
+        // Admin: backup, retention, device management
         .route("/admin/backup", get(crate::backup::backup_database))
         .route("/admin/retention", get(crate::backup::retention_info))
+        .route(
+            "/admin/devices/:device_id",
+            delete(admin_delete_device_handler),
+        )
         .layer(axum::middleware::from_fn_with_state(
             state.clone(),
             crate::auth_middleware::require_auth,

--- a/ferrite-server/src/store.rs
+++ b/ferrite-server/src/store.rs
@@ -381,6 +381,15 @@ impl Store {
         Ok(changed > 0)
     }
 
+    /// Delete a device by device_id string.
+    pub fn delete_device_by_id(&self, device_id: &str) -> SqlResult<bool> {
+        let changed = self.conn.execute(
+            "DELETE FROM devices WHERE device_id = ?1",
+            params![device_id],
+        )?;
+        Ok(changed > 0)
+    }
+
     /// Touch a device by device_key and update its status.
     pub fn touch_device_by_key(&self, device_key: i64, status: &str) -> SqlResult<Option<i64>> {
         let changed = self.conn.execute(


### PR DESCRIPTION
## Summary
- Remove explicit `<title>` from index.html — Dioxus was injecting its own, causing "Ferrite DemoFerrite Demo"
- Add `DELETE /admin/devices/:device_id` endpoint to delete devices by ID string
- Update ESP32-C3 firmware to use port 4001 (RPi gateway HTTP ingest)

## Test plan
- [x] Server builds and 38/38 tests pass
- [ ] CI passes
- [ ] Page title shows "Ferrite Demo" (not doubled)
- [ ] `curl -X DELETE .../admin/devices/unknown` removes the ghost device

🤖 Generated with [Claude Code](https://claude.com/claude-code)