### PR TITLE
feat: Sprint 1 — ferrite CLI and crash deduplication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ ferrite.db-wal
 .env.*
 !.env.example
 log.log
+
+# Plans
+plan.md

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
   "ferrite-dashboard",
   "ferrite-provision",
   "ferrite-gateway",
+  "ferrite-cli",
 ]
 exclude = [
   "examples/embassy-nrf52840",

--- a/ferrite-cli/Cargo.toml
+++ b/ferrite-cli/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "ferrite-cli"
+version = "0.1.0"
+edition = "2021"
+
+[[bin]]
+name = "ferrite"
+path = "src/main.rs"
+
+[dependencies]
+clap = { version = "4", features = ["derive"] }
+reqwest = { version = "0.12", features = ["json", "blocking"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+toml = "0.8"
+anyhow = "1"
+tabled = "0.17"
+base64 = "0.22"
+humantime = "2"
+chrono = { version = "0.4", features = ["serde"] }

--- a/ferrite-cli/src/api.rs
+++ b/ferrite-cli/src/api.rs
@@ -133,10 +133,7 @@ impl ApiClient {
     }
 
     /// Check that a response was successful; surface server error messages.
-    fn check_response(
-        &self,
-        resp: reqwest::blocking::Response,
-    ) -> Result<serde_json::Value> {
+    fn check_response(&self, resp: reqwest::blocking::Response) -> Result<serde_json::Value> {
         let status = resp.status();
         let body: serde_json::Value = resp.json().context("failed to parse response body")?;
         if !status.is_success() {
@@ -313,11 +310,7 @@ impl ApiClient {
         Ok(groups)
     }
 
-    pub fn create_group(
-        &self,
-        name: &str,
-        description: Option<&str>,
-    ) -> Result<DeviceGroup> {
+    pub fn create_group(&self, name: &str, description: Option<&str>) -> Result<DeviceGroup> {
         let mut body = serde_json::json!({ "name": name });
         if let Some(desc) = description {
             body["description"] = serde_json::Value::String(desc.to_string());

--- a/ferrite-cli/src/api.rs
+++ b/ferrite-cli/src/api.rs
@@ -1,0 +1,460 @@
+use anyhow::{bail, Context, Result};
+use reqwest::blocking::Client;
+use serde::{Deserialize, Serialize};
+use std::time::Duration;
+use tabled::Tabled;
+
+/// API client for the ferrite-server REST API.
+pub struct ApiClient {
+    pub base_url: String,
+    pub auth_header: String,
+    pub http: Client,
+}
+
+// ---------------------------------------------------------------------------
+// API response types (matching ferrite-server/src/store.rs)
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Serialize, Deserialize, Tabled)]
+pub struct Device {
+    pub id: i64,
+    pub device_id: String,
+    pub firmware_version: String,
+    pub build_id: u64,
+    pub first_seen: String,
+    pub last_seen: String,
+    #[tabled(display_with = "display_option")]
+    pub device_key: Option<i64>,
+    #[tabled(display_with = "display_option")]
+    pub name: Option<String>,
+    #[tabled(display_with = "display_option")]
+    pub status: Option<String>,
+    #[tabled(display_with = "display_option")]
+    pub tags: Option<String>,
+    #[tabled(display_with = "display_option")]
+    pub provisioned_by: Option<String>,
+    #[tabled(display_with = "display_option")]
+    pub provisioned_at: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Tabled)]
+pub struct FaultEvent {
+    pub id: i64,
+    pub device_rowid: i64,
+    pub device_id: String,
+    pub fault_type: u8,
+    #[tabled(display_with = "display_hex32")]
+    pub pc: u32,
+    #[tabled(display_with = "display_hex32")]
+    pub lr: u32,
+    #[tabled(display_with = "display_hex32")]
+    pub cfsr: u32,
+    #[tabled(display_with = "display_hex32")]
+    pub hfsr: u32,
+    #[tabled(display_with = "display_hex32")]
+    pub mmfar: u32,
+    #[tabled(display_with = "display_hex32")]
+    pub bfar: u32,
+    #[tabled(display_with = "display_hex32")]
+    pub sp: u32,
+    pub stack_snapshot: String,
+    #[tabled(display_with = "display_option")]
+    pub symbol: Option<String>,
+    pub created_at: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Tabled)]
+pub struct MetricRow {
+    pub id: i64,
+    pub device_rowid: i64,
+    pub device_id: String,
+    pub key: String,
+    pub metric_type: u8,
+    pub value_json: String,
+    pub timestamp_ticks: u64,
+    pub created_at: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Tabled)]
+pub struct DeviceGroup {
+    pub id: i64,
+    pub name: String,
+    #[tabled(display_with = "display_option")]
+    pub description: Option<String>,
+    pub device_count: i64,
+    pub created_at: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Tabled)]
+pub struct OtaTarget {
+    pub id: i64,
+    pub device_id: String,
+    pub target_version: String,
+    pub target_build_id: i64,
+    #[tabled(display_with = "display_option")]
+    pub firmware_url: Option<String>,
+    pub created_at: String,
+}
+
+// ---------------------------------------------------------------------------
+// Display helpers for tabled
+// ---------------------------------------------------------------------------
+
+fn display_option<T: std::fmt::Display>(o: &Option<T>) -> String {
+    match o {
+        Some(v) => v.to_string(),
+        None => "-".to_string(),
+    }
+}
+
+fn display_hex32(v: &u32) -> String {
+    format!("0x{v:08X}")
+}
+
+// ---------------------------------------------------------------------------
+// ApiClient implementation
+// ---------------------------------------------------------------------------
+
+impl ApiClient {
+    pub fn new(base_url: &str, auth_header: &str) -> Result<Self> {
+        let http = Client::builder()
+            .timeout(Duration::from_secs(30))
+            .build()
+            .context("failed to build HTTP client")?;
+        Ok(Self {
+            base_url: base_url.trim_end_matches('/').to_string(),
+            auth_header: auth_header.to_string(),
+            http,
+        })
+    }
+
+    fn url(&self, path: &str) -> String {
+        format!("{}{}", self.base_url, path)
+    }
+
+    /// Check that a response was successful; surface server error messages.
+    fn check_response(
+        &self,
+        resp: reqwest::blocking::Response,
+    ) -> Result<serde_json::Value> {
+        let status = resp.status();
+        let body: serde_json::Value = resp.json().context("failed to parse response body")?;
+        if !status.is_success() {
+            let err_msg = body
+                .get("error")
+                .and_then(|v| v.as_str())
+                .unwrap_or("unknown error");
+            bail!("server returned {}: {}", status, err_msg);
+        }
+        Ok(body)
+    }
+
+    // -- Devices --
+
+    pub fn list_devices(&self) -> Result<Vec<Device>> {
+        let resp = self
+            .http
+            .get(self.url("/devices"))
+            .header("Authorization", &self.auth_header)
+            .send()
+            .context("failed to reach server")?;
+        let body = self.check_response(resp)?;
+        let devices: Vec<Device> = serde_json::from_value(
+            body.get("devices")
+                .cloned()
+                .unwrap_or(serde_json::Value::Array(vec![])),
+        )?;
+        Ok(devices)
+    }
+
+    pub fn get_device(&self, device_key: &str) -> Result<Device> {
+        let resp = self
+            .http
+            .get(self.url(&format!("/devices/{device_key}")))
+            .header("Authorization", &self.auth_header)
+            .send()
+            .context("failed to reach server")?;
+        let body = self.check_response(resp)?;
+        let device: Device =
+            serde_json::from_value(body.get("device").cloned().unwrap_or_default())?;
+        Ok(device)
+    }
+
+    pub fn delete_device(&self, device_key: &str) -> Result<()> {
+        let resp = self
+            .http
+            .delete(self.url(&format!("/devices/{device_key}")))
+            .header("Authorization", &self.auth_header)
+            .send()
+            .context("failed to reach server")?;
+        self.check_response(resp)?;
+        Ok(())
+    }
+
+    pub fn list_device_faults(
+        &self,
+        device_id: &str,
+        since: Option<&str>,
+    ) -> Result<Vec<FaultEvent>> {
+        let mut url = format!("/devices/{device_id}/faults");
+        if let Some(s) = since {
+            url.push_str(&format!("?since={s}"));
+        }
+        let resp = self
+            .http
+            .get(self.url(&url))
+            .header("Authorization", &self.auth_header)
+            .send()
+            .context("failed to reach server")?;
+        let body = self.check_response(resp)?;
+        let faults: Vec<FaultEvent> = serde_json::from_value(
+            body.get("faults")
+                .cloned()
+                .unwrap_or(serde_json::Value::Array(vec![])),
+        )?;
+        Ok(faults)
+    }
+
+    pub fn list_device_metrics(
+        &self,
+        device_id: &str,
+        since: Option<&str>,
+    ) -> Result<Vec<MetricRow>> {
+        let mut url = format!("/devices/{device_id}/metrics");
+        if let Some(s) = since {
+            url.push_str(&format!("?since={s}"));
+        }
+        let resp = self
+            .http
+            .get(self.url(&url))
+            .header("Authorization", &self.auth_header)
+            .send()
+            .context("failed to reach server")?;
+        let body = self.check_response(resp)?;
+        let metrics: Vec<MetricRow> = serde_json::from_value(
+            body.get("metrics")
+                .cloned()
+                .unwrap_or(serde_json::Value::Array(vec![])),
+        )?;
+        Ok(metrics)
+    }
+
+    // -- Faults (all) --
+
+    pub fn list_all_faults(&self, since: Option<&str>) -> Result<Vec<FaultEvent>> {
+        let mut url = "/faults".to_string();
+        if let Some(s) = since {
+            url.push_str(&format!("?since={s}"));
+        }
+        let resp = self
+            .http
+            .get(self.url(&url))
+            .header("Authorization", &self.auth_header)
+            .send()
+            .context("failed to reach server")?;
+        let body = self.check_response(resp)?;
+        let faults: Vec<FaultEvent> = serde_json::from_value(
+            body.get("faults")
+                .cloned()
+                .unwrap_or(serde_json::Value::Array(vec![])),
+        )?;
+        Ok(faults)
+    }
+
+    // -- Metrics (all) --
+
+    pub fn list_all_metrics(
+        &self,
+        since: Option<&str>,
+        key: Option<&str>,
+    ) -> Result<Vec<MetricRow>> {
+        let mut params = vec![];
+        if let Some(s) = since {
+            params.push(format!("since={s}"));
+        }
+        if let Some(k) = key {
+            params.push(format!("key={k}"));
+        }
+        let query = if params.is_empty() {
+            String::new()
+        } else {
+            format!("?{}", params.join("&"))
+        };
+        let resp = self
+            .http
+            .get(self.url(&format!("/metrics{query}")))
+            .header("Authorization", &self.auth_header)
+            .send()
+            .context("failed to reach server")?;
+        let body = self.check_response(resp)?;
+        let metrics: Vec<MetricRow> = serde_json::from_value(
+            body.get("metrics")
+                .cloned()
+                .unwrap_or(serde_json::Value::Array(vec![])),
+        )?;
+        Ok(metrics)
+    }
+
+    // -- Groups --
+
+    pub fn list_groups(&self) -> Result<Vec<DeviceGroup>> {
+        let resp = self
+            .http
+            .get(self.url("/groups"))
+            .header("Authorization", &self.auth_header)
+            .send()
+            .context("failed to reach server")?;
+        let body = self.check_response(resp)?;
+        let groups: Vec<DeviceGroup> = serde_json::from_value(
+            body.get("groups")
+                .cloned()
+                .unwrap_or(serde_json::Value::Array(vec![])),
+        )?;
+        Ok(groups)
+    }
+
+    pub fn create_group(
+        &self,
+        name: &str,
+        description: Option<&str>,
+    ) -> Result<DeviceGroup> {
+        let mut body = serde_json::json!({ "name": name });
+        if let Some(desc) = description {
+            body["description"] = serde_json::Value::String(desc.to_string());
+        }
+        let resp = self
+            .http
+            .post(self.url("/groups"))
+            .header("Authorization", &self.auth_header)
+            .json(&body)
+            .send()
+            .context("failed to reach server")?;
+        let resp_body = self.check_response(resp)?;
+        let group: DeviceGroup =
+            serde_json::from_value(resp_body.get("group").cloned().unwrap_or_default())?;
+        Ok(group)
+    }
+
+    pub fn add_device_to_group(&self, group_id: i64, device_id: &str) -> Result<()> {
+        let resp = self
+            .http
+            .post(self.url(&format!("/groups/{group_id}/devices/{device_id}")))
+            .header("Authorization", &self.auth_header)
+            .send()
+            .context("failed to reach server")?;
+        self.check_response(resp)?;
+        Ok(())
+    }
+
+    pub fn remove_device_from_group(&self, group_id: i64, device_id: &str) -> Result<()> {
+        let resp = self
+            .http
+            .delete(self.url(&format!("/groups/{group_id}/devices/{device_id}")))
+            .header("Authorization", &self.auth_header)
+            .send()
+            .context("failed to reach server")?;
+        self.check_response(resp)?;
+        Ok(())
+    }
+
+    pub fn list_group_devices(&self, group_id: i64) -> Result<Vec<Device>> {
+        let resp = self
+            .http
+            .get(self.url(&format!("/groups/{group_id}/devices")))
+            .header("Authorization", &self.auth_header)
+            .send()
+            .context("failed to reach server")?;
+        let body = self.check_response(resp)?;
+        let devices: Vec<Device> = serde_json::from_value(
+            body.get("devices")
+                .cloned()
+                .unwrap_or(serde_json::Value::Array(vec![])),
+        )?;
+        Ok(devices)
+    }
+
+    // -- OTA --
+
+    pub fn set_ota_target(
+        &self,
+        device_id: &str,
+        target_version: &str,
+        target_build_id: i64,
+        firmware_url: Option<&str>,
+    ) -> Result<OtaTarget> {
+        let mut body = serde_json::json!({
+            "device_id": device_id,
+            "target_version": target_version,
+            "target_build_id": target_build_id,
+        });
+        if let Some(url) = firmware_url {
+            body["firmware_url"] = serde_json::Value::String(url.to_string());
+        }
+        let resp = self
+            .http
+            .post(self.url("/ota/targets"))
+            .header("Authorization", &self.auth_header)
+            .json(&body)
+            .send()
+            .context("failed to reach server")?;
+        let resp_body = self.check_response(resp)?;
+        let target: OtaTarget =
+            serde_json::from_value(resp_body.get("target").cloned().unwrap_or_default())?;
+        Ok(target)
+    }
+
+    pub fn get_ota_target(&self, device_id: &str) -> Result<OtaTarget> {
+        let resp = self
+            .http
+            .get(self.url(&format!("/ota/targets/{device_id}")))
+            .header("Authorization", &self.auth_header)
+            .send()
+            .context("failed to reach server")?;
+        let resp_body = self.check_response(resp)?;
+        let target: OtaTarget =
+            serde_json::from_value(resp_body.get("target").cloned().unwrap_or_default())?;
+        Ok(target)
+    }
+
+    pub fn delete_ota_target(&self, device_id: &str) -> Result<()> {
+        let resp = self
+            .http
+            .delete(self.url(&format!("/ota/targets/{device_id}")))
+            .header("Authorization", &self.auth_header)
+            .send()
+            .context("failed to reach server")?;
+        self.check_response(resp)?;
+        Ok(())
+    }
+
+    pub fn list_ota_targets(&self) -> Result<Vec<OtaTarget>> {
+        let resp = self
+            .http
+            .get(self.url("/ota/targets"))
+            .header("Authorization", &self.auth_header)
+            .send()
+            .context("failed to reach server")?;
+        let body = self.check_response(resp)?;
+        let targets: Vec<OtaTarget> = serde_json::from_value(
+            body.get("targets")
+                .cloned()
+                .unwrap_or(serde_json::Value::Array(vec![])),
+        )?;
+        Ok(targets)
+    }
+
+    // -- Health (for login validation) --
+
+    pub fn health(&self) -> Result<()> {
+        let resp = self
+            .http
+            .get(self.url("/health"))
+            .header("Authorization", &self.auth_header)
+            .send()
+            .context("failed to reach server")?;
+        if !resp.status().is_success() {
+            bail!("server returned {}", resp.status());
+        }
+        Ok(())
+    }
+}

--- a/ferrite-cli/src/commands/devices.rs
+++ b/ferrite-cli/src/commands/devices.rs
@@ -1,0 +1,50 @@
+use anyhow::Result;
+use clap::Subcommand;
+
+use crate::api::ApiClient;
+use crate::output::{print_items, OutputFormat};
+
+#[derive(Debug, Subcommand)]
+pub enum DevicesCommand {
+    /// List all known devices
+    List,
+    /// Show detailed info for a device (by hex device key, e.g. A300F1B2)
+    Inspect {
+        /// Device key in hex (e.g. A300F1B2)
+        device_key: String,
+    },
+    /// Delete a device by hex device key
+    Delete {
+        /// Device key in hex (e.g. A300F1B2)
+        device_key: String,
+    },
+}
+
+pub fn run(cmd: &DevicesCommand, client: &ApiClient, format: OutputFormat) -> Result<()> {
+    match cmd {
+        DevicesCommand::List => {
+            let devices = client.list_devices()?;
+            print_items(&devices, format)?;
+        }
+        DevicesCommand::Inspect { device_key } => {
+            let device = client.get_device(device_key)?;
+            println!("=== Device ===");
+            print_items(&[device.clone()], format)?;
+
+            // Fetch recent faults for this device
+            let faults = client.list_device_faults(&device.device_id, None)?;
+            println!("\n=== Recent Faults ({}) ===", faults.len());
+            print_items(&faults, format)?;
+
+            // Fetch recent metrics for this device
+            let metrics = client.list_device_metrics(&device.device_id, None)?;
+            println!("\n=== Recent Metrics ({}) ===", metrics.len());
+            print_items(&metrics, format)?;
+        }
+        DevicesCommand::Delete { device_key } => {
+            client.delete_device(device_key)?;
+            println!("Device {device_key} deleted.");
+        }
+    }
+    Ok(())
+}

--- a/ferrite-cli/src/commands/faults.rs
+++ b/ferrite-cli/src/commands/faults.rs
@@ -17,11 +17,7 @@ pub struct FaultsArgs {
 }
 
 pub fn run(args: &FaultsArgs, client: &ApiClient, format: OutputFormat) -> Result<()> {
-    let since = args
-        .since
-        .as_deref()
-        .map(duration_to_since)
-        .transpose()?;
+    let since = args.since.as_deref().map(duration_to_since).transpose()?;
 
     let faults = if let Some(device_id) = &args.device {
         client.list_device_faults(device_id, since.as_deref())?

--- a/ferrite-cli/src/commands/faults.rs
+++ b/ferrite-cli/src/commands/faults.rs
@@ -1,0 +1,34 @@
+use anyhow::Result;
+use clap::Args;
+
+use super::duration_to_since;
+use crate::api::ApiClient;
+use crate::output::{print_items, OutputFormat};
+
+#[derive(Debug, Args)]
+pub struct FaultsArgs {
+    /// Filter by device_id
+    #[arg(long)]
+    device: Option<String>,
+
+    /// Show faults since duration (e.g. "1h", "30m", "7d")
+    #[arg(long)]
+    since: Option<String>,
+}
+
+pub fn run(args: &FaultsArgs, client: &ApiClient, format: OutputFormat) -> Result<()> {
+    let since = args
+        .since
+        .as_deref()
+        .map(duration_to_since)
+        .transpose()?;
+
+    let faults = if let Some(device_id) = &args.device {
+        client.list_device_faults(device_id, since.as_deref())?
+    } else {
+        client.list_all_faults(since.as_deref())?
+    };
+
+    print_items(&faults, format)?;
+    Ok(())
+}

--- a/ferrite-cli/src/commands/groups.rs
+++ b/ferrite-cli/src/commands/groups.rs
@@ -1,0 +1,70 @@
+use anyhow::Result;
+use clap::Subcommand;
+
+use crate::api::ApiClient;
+use crate::output::{print_items, OutputFormat};
+
+#[derive(Debug, Subcommand)]
+pub enum GroupsCommand {
+    /// List all device groups
+    List,
+    /// Create a new device group
+    Create {
+        /// Group name
+        name: String,
+        /// Optional description
+        #[arg(long)]
+        description: Option<String>,
+    },
+    /// Add a device to a group
+    AddDevice {
+        /// Group ID
+        group_id: i64,
+        /// Device ID string
+        device_id: String,
+    },
+    /// Remove a device from a group
+    RemoveDevice {
+        /// Group ID
+        group_id: i64,
+        /// Device ID string
+        device_id: String,
+    },
+    /// List devices in a group
+    Devices {
+        /// Group ID
+        group_id: i64,
+    },
+}
+
+pub fn run(cmd: &GroupsCommand, client: &ApiClient, format: OutputFormat) -> Result<()> {
+    match cmd {
+        GroupsCommand::List => {
+            let groups = client.list_groups()?;
+            print_items(&groups, format)?;
+        }
+        GroupsCommand::Create { name, description } => {
+            let group = client.create_group(name, description.as_deref())?;
+            println!("Created group #{}: {}", group.id, group.name);
+        }
+        GroupsCommand::AddDevice {
+            group_id,
+            device_id,
+        } => {
+            client.add_device_to_group(*group_id, device_id)?;
+            println!("Added device {device_id} to group {group_id}.");
+        }
+        GroupsCommand::RemoveDevice {
+            group_id,
+            device_id,
+        } => {
+            client.remove_device_from_group(*group_id, device_id)?;
+            println!("Removed device {device_id} from group {group_id}.");
+        }
+        GroupsCommand::Devices { group_id } => {
+            let devices = client.list_group_devices(*group_id)?;
+            print_items(&devices, format)?;
+        }
+    }
+    Ok(())
+}

--- a/ferrite-cli/src/commands/metrics.rs
+++ b/ferrite-cli/src/commands/metrics.rs
@@ -21,11 +21,7 @@ pub struct MetricsArgs {
 }
 
 pub fn run(args: &MetricsArgs, client: &ApiClient, format: OutputFormat) -> Result<()> {
-    let since = args
-        .since
-        .as_deref()
-        .map(duration_to_since)
-        .transpose()?;
+    let since = args.since.as_deref().map(duration_to_since).transpose()?;
 
     let metrics = if let Some(device_id) = &args.device {
         client.list_device_metrics(device_id, since.as_deref())?

--- a/ferrite-cli/src/commands/metrics.rs
+++ b/ferrite-cli/src/commands/metrics.rs
@@ -1,0 +1,38 @@
+use anyhow::Result;
+use clap::Args;
+
+use super::duration_to_since;
+use crate::api::ApiClient;
+use crate::output::{print_items, OutputFormat};
+
+#[derive(Debug, Args)]
+pub struct MetricsArgs {
+    /// Filter by metric key name
+    #[arg(long)]
+    key: Option<String>,
+
+    /// Filter by device_id
+    #[arg(long)]
+    device: Option<String>,
+
+    /// Show metrics since duration (e.g. "1h", "30m", "7d")
+    #[arg(long)]
+    since: Option<String>,
+}
+
+pub fn run(args: &MetricsArgs, client: &ApiClient, format: OutputFormat) -> Result<()> {
+    let since = args
+        .since
+        .as_deref()
+        .map(duration_to_since)
+        .transpose()?;
+
+    let metrics = if let Some(device_id) = &args.device {
+        client.list_device_metrics(device_id, since.as_deref())?
+    } else {
+        client.list_all_metrics(since.as_deref(), args.key.as_deref())?
+    };
+
+    print_items(&metrics, format)?;
+    Ok(())
+}

--- a/ferrite-cli/src/commands/mod.rs
+++ b/ferrite-cli/src/commands/mod.rs
@@ -1,0 +1,15 @@
+pub mod devices;
+pub mod faults;
+pub mod groups;
+pub mod metrics;
+pub mod ota;
+
+use chrono::Utc;
+
+/// Convert a human duration string (e.g. "1h", "30m") to an ISO 8601 datetime
+/// representing `now - duration`.
+pub fn duration_to_since(dur_str: &str) -> anyhow::Result<String> {
+    let duration = humantime::parse_duration(dur_str)?;
+    let since = Utc::now() - chrono::Duration::from_std(duration)?;
+    Ok(since.to_rfc3339())
+}

--- a/ferrite-cli/src/commands/ota.rs
+++ b/ferrite-cli/src/commands/ota.rs
@@ -1,0 +1,63 @@
+use anyhow::Result;
+use clap::Subcommand;
+
+use crate::api::ApiClient;
+use crate::output::{print_items, OutputFormat};
+
+#[derive(Debug, Subcommand)]
+pub enum OtaCommand {
+    /// Deploy an OTA target for a device
+    Deploy {
+        /// Device ID string
+        device_id: String,
+        /// Target firmware version
+        #[arg(long)]
+        version: String,
+        /// Target build ID
+        #[arg(long, default_value = "0")]
+        build_id: i64,
+        /// Optional firmware download URL
+        #[arg(long)]
+        firmware_url: Option<String>,
+    },
+    /// Show OTA target status for a device
+    Status {
+        /// Device ID string
+        device_id: String,
+    },
+    /// List all OTA targets
+    List,
+    /// Cancel (remove) OTA target for a device
+    Cancel {
+        /// Device ID string
+        device_id: String,
+    },
+}
+
+pub fn run(cmd: &OtaCommand, client: &ApiClient, format: OutputFormat) -> Result<()> {
+    match cmd {
+        OtaCommand::Deploy {
+            device_id,
+            version,
+            build_id,
+            firmware_url,
+        } => {
+            let target =
+                client.set_ota_target(device_id, version, *build_id, firmware_url.as_deref())?;
+            println!("OTA target set for {device_id}: {}", target.target_version);
+        }
+        OtaCommand::Status { device_id } => {
+            let target = client.get_ota_target(device_id)?;
+            print_items(&[target], format)?;
+        }
+        OtaCommand::List => {
+            let targets = client.list_ota_targets()?;
+            print_items(&targets, format)?;
+        }
+        OtaCommand::Cancel { device_id } => {
+            client.delete_ota_target(device_id)?;
+            println!("OTA target cancelled for {device_id}.");
+        }
+    }
+    Ok(())
+}

--- a/ferrite-cli/src/config.rs
+++ b/ferrite-cli/src/config.rs
@@ -1,0 +1,67 @@
+use anyhow::{Context, Result};
+use base64::Engine;
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::path::PathBuf;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CliConfig {
+    pub server: String,
+    pub username: String,
+    pub password: String,
+    pub default_format: Option<String>,
+}
+
+impl Default for CliConfig {
+    fn default() -> Self {
+        Self {
+            server: "http://localhost:4000".to_string(),
+            username: "admin".to_string(),
+            password: "admin".to_string(),
+            default_format: None,
+        }
+    }
+}
+
+fn config_path() -> Result<PathBuf> {
+    let home = std::env::var("HOME").context("HOME not set")?;
+    Ok(PathBuf::from(home).join(".ferrite").join("config.toml"))
+}
+
+impl CliConfig {
+    pub fn load() -> Result<Self> {
+        let path = config_path()?;
+        if !path.exists() {
+            return Ok(Self::default());
+        }
+        let content = fs::read_to_string(&path)
+            .with_context(|| format!("failed to read {}", path.display()))?;
+        let config: Self =
+            toml::from_str(&content).with_context(|| "failed to parse config.toml")?;
+        Ok(config)
+    }
+
+    pub fn save(&self) -> Result<()> {
+        let path = config_path()?;
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        let content = toml::to_string_pretty(self)?;
+        fs::write(&path, &content)?;
+
+        // Set 0600 permissions on Unix
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            fs::set_permissions(&path, fs::Permissions::from_mode(0o600))?;
+        }
+
+        Ok(())
+    }
+}
+
+pub fn make_auth_header(username: &str, password: &str) -> String {
+    let credentials = format!("{username}:{password}");
+    let encoded = base64::engine::general_purpose::STANDARD.encode(credentials.as_bytes());
+    format!("Basic {encoded}")
+}

--- a/ferrite-cli/src/main.rs
+++ b/ferrite-cli/src/main.rs
@@ -1,0 +1,123 @@
+mod api;
+mod commands;
+mod config;
+mod output;
+
+use anyhow::Result;
+use clap::{Parser, Subcommand};
+
+use api::ApiClient;
+use config::{make_auth_header, CliConfig};
+use output::OutputFormat;
+
+#[derive(Parser)]
+#[command(name = "ferrite", about = "CLI for the ferrite-server REST API")]
+struct Cli {
+    /// Server URL (overrides config)
+    #[arg(long, global = true)]
+    server: Option<String>,
+
+    /// Output format
+    #[arg(long, global = true, value_enum)]
+    format: Option<OutputFormat>,
+
+    #[command(subcommand)]
+    command: Commands,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    /// Save server credentials and validate connectivity
+    Login {
+        /// Server URL (e.g. http://localhost:4000)
+        #[arg(long)]
+        server: Option<String>,
+        /// Username
+        #[arg(long)]
+        user: Option<String>,
+        /// Password
+        #[arg(long)]
+        pass: Option<String>,
+    },
+    /// Manage devices
+    Devices {
+        #[command(subcommand)]
+        cmd: commands::devices::DevicesCommand,
+    },
+    /// Query fault events
+    Faults(commands::faults::FaultsArgs),
+    /// Manage device groups
+    Groups {
+        #[command(subcommand)]
+        cmd: commands::groups::GroupsCommand,
+    },
+    /// Query metrics
+    Metrics(commands::metrics::MetricsArgs),
+    /// Manage OTA firmware targets
+    Ota {
+        #[command(subcommand)]
+        cmd: commands::ota::OtaCommand,
+    },
+}
+
+fn main() -> Result<()> {
+    let cli = Cli::parse();
+
+    match &cli.command {
+        Commands::Login { server, user, pass } => {
+            let mut cfg = CliConfig::load()?;
+
+            if let Some(s) = server {
+                cfg.server = s.clone();
+            }
+            if let Some(u) = user {
+                cfg.username = u.clone();
+            }
+            if let Some(p) = pass {
+                cfg.password = p.clone();
+            }
+
+            // Validate connectivity
+            let auth = make_auth_header(&cfg.username, &cfg.password);
+            let client = ApiClient::new(&cfg.server, &auth)?;
+            client.health()?;
+
+            cfg.save()?;
+            println!("Logged in to {} as {}", cfg.server, cfg.username);
+        }
+        cmd => {
+            let cfg = CliConfig::load()?;
+            let server = cli
+                .server
+                .as_deref()
+                .unwrap_or(&cfg.server);
+            let auth = make_auth_header(&cfg.username, &cfg.password);
+            let client = ApiClient::new(server, &auth)?;
+
+            let format = cli
+                .format
+                .unwrap_or_else(|| OutputFormat::from_str_opt(cfg.default_format.as_deref()));
+
+            match cmd {
+                Commands::Devices { cmd: subcmd } => {
+                    commands::devices::run(subcmd, &client, format)?;
+                }
+                Commands::Faults(args) => {
+                    commands::faults::run(args, &client, format)?;
+                }
+                Commands::Groups { cmd: subcmd } => {
+                    commands::groups::run(subcmd, &client, format)?;
+                }
+                Commands::Metrics(args) => {
+                    commands::metrics::run(args, &client, format)?;
+                }
+                Commands::Ota { cmd: subcmd } => {
+                    commands::ota::run(subcmd, &client, format)?;
+                }
+                Commands::Login { .. } => unreachable!(),
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/ferrite-cli/src/main.rs
+++ b/ferrite-cli/src/main.rs
@@ -87,10 +87,7 @@ fn main() -> Result<()> {
         }
         cmd => {
             let cfg = CliConfig::load()?;
-            let server = cli
-                .server
-                .as_deref()
-                .unwrap_or(&cfg.server);
+            let server = cli.server.as_deref().unwrap_or(&cfg.server);
             let auth = make_auth_header(&cfg.username, &cfg.password);
             let client = ApiClient::new(server, &auth)?;
 

--- a/ferrite-cli/src/output.rs
+++ b/ferrite-cli/src/output.rs
@@ -1,0 +1,77 @@
+use anyhow::Result;
+use clap::ValueEnum;
+use serde::Serialize;
+use tabled::{settings::Style, Table, Tabled};
+
+#[derive(Debug, Clone, Copy, ValueEnum)]
+pub enum OutputFormat {
+    Table,
+    Json,
+    Csv,
+}
+
+impl Default for OutputFormat {
+    fn default() -> Self {
+        Self::Table
+    }
+}
+
+impl OutputFormat {
+    /// Parse from an optional string (from config file).
+    pub fn from_str_opt(s: Option<&str>) -> Self {
+        match s.map(|s| s.to_lowercase()).as_deref() {
+            Some("json") => Self::Json,
+            Some("csv") => Self::Csv,
+            _ => Self::Table,
+        }
+    }
+}
+
+pub fn print_items<T: Serialize + Tabled>(items: &[T], format: OutputFormat) -> Result<()> {
+    match format {
+        OutputFormat::Table => {
+            if items.is_empty() {
+                println!("(no results)");
+            } else {
+                let table = Table::new(items).with(Style::modern_rounded()).to_string();
+                println!("{table}");
+            }
+        }
+        OutputFormat::Json => {
+            let json = serde_json::to_string_pretty(items)?;
+            println!("{json}");
+        }
+        OutputFormat::Csv => {
+            if items.is_empty() {
+                return Ok(());
+            }
+            // Use serde_json to get field names from first item, then print rows
+            let values: Vec<serde_json::Value> = items
+                .iter()
+                .map(|item| serde_json::to_value(item))
+                .collect::<Result<_, _>>()?;
+            if let Some(serde_json::Value::Object(first)) = values.first() {
+                let headers: Vec<&str> = first.keys().map(|k| k.as_str()).collect();
+                println!("{}", headers.join(","));
+                for val in &values {
+                    if let serde_json::Value::Object(map) = val {
+                        let row: Vec<String> = headers
+                            .iter()
+                            .map(|h| {
+                                map.get(*h)
+                                    .map(|v| match v {
+                                        serde_json::Value::String(s) => s.clone(),
+                                        serde_json::Value::Null => String::new(),
+                                        other => other.to_string(),
+                                    })
+                                    .unwrap_or_default()
+                            })
+                            .collect();
+                        println!("{}", row.join(","));
+                    }
+                }
+            }
+        }
+    }
+    Ok(())
+}

--- a/ferrite-dashboard/Dioxus.toml
+++ b/ferrite-dashboard/Dioxus.toml
@@ -45,4 +45,7 @@ backend = "http://localhost:4000/events"
 backend = "http://localhost:4000/admin"
 
 [[web.proxy]]
+backend = "http://localhost:4000/crashes"
+
+[[web.proxy]]
 backend = "http://localhost:4000/ota"

--- a/ferrite-dashboard/src/api/client.rs
+++ b/ferrite-dashboard/src/api/client.rs
@@ -219,6 +219,59 @@ impl ApiClient {
         }
     }
 
+    pub async fn list_crash_groups(&self) -> Result<Vec<CrashGroup>, ApiError> {
+        let url = format!("{}/crashes", self.base_url);
+        let resp = self
+            .build_get(&url)
+            .send()
+            .await
+            .map_err(|e| ApiError::Network(e.to_string()))?;
+        match resp.status().as_u16() {
+            200 => {
+                #[derive(Deserialize)]
+                struct Wrapper {
+                    crash_groups: Vec<CrashGroup>,
+                }
+                let w: Wrapper = resp
+                    .json()
+                    .await
+                    .map_err(|e| ApiError::Parse(e.to_string()))?;
+                Ok(w.crash_groups)
+            }
+            401 => Err(ApiError::Unauthorized),
+            code => Err(ApiError::Server(format!("HTTP {}", code))),
+        }
+    }
+
+    pub async fn get_crash_group(
+        &self,
+        id: i64,
+    ) -> Result<(CrashGroup, Vec<FaultEvent>), ApiError> {
+        let url = format!("{}/crashes/{}", self.base_url, id);
+        let resp = self
+            .build_get(&url)
+            .send()
+            .await
+            .map_err(|e| ApiError::Network(e.to_string()))?;
+        match resp.status().as_u16() {
+            200 => {
+                #[derive(Deserialize)]
+                struct Wrapper {
+                    group: CrashGroup,
+                    occurrences: Vec<FaultEvent>,
+                }
+                let w: Wrapper = resp
+                    .json()
+                    .await
+                    .map_err(|e| ApiError::Parse(e.to_string()))?;
+                Ok((w.group, w.occurrences))
+            }
+            401 => Err(ApiError::Unauthorized),
+            404 => Err(ApiError::NotFound),
+            code => Err(ApiError::Server(format!("HTTP {}", code))),
+        }
+    }
+
     pub async fn register_device(
         &self,
         device_key: &str,

--- a/ferrite-dashboard/src/api/types.rs
+++ b/ferrite-dashboard/src/api/types.rs
@@ -105,6 +105,31 @@ pub struct MetricRow {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct CrashGroup {
+    pub id: i64,
+    pub signature_hash: String,
+    pub pc: u32,
+    pub fault_type: u8,
+    pub first_seen: String,
+    pub last_seen: String,
+    pub occurrence_count: i64,
+    pub affected_device_count: i64,
+    pub title: Option<String>,
+}
+
+impl CrashGroup {
+    pub fn fault_type_name(&self) -> &'static str {
+        match self.fault_type {
+            0 => "HardFault",
+            1 => "MemManage",
+            2 => "BusFault",
+            3 => "UsageFault",
+            _ => "Unknown",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct TraceEntry {
     pub id: String,
     pub device_id: String,

--- a/ferrite-dashboard/src/components/navbar.rs
+++ b/ferrite-dashboard/src/components/navbar.rs
@@ -157,6 +157,12 @@ pub fn Navbar() -> Element {
                         icon_path: "M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4c-.77-.833-1.964-.833-2.732 0L4.082 16.5c-.77.833.192 2.5 1.732 2.5z",
                         on_click: move |_| mobile_open.set(false),
                     }
+                    SidebarLink {
+                        to: Route::Crashes {},
+                        label: "Crashes",
+                        icon_path: "M19.428 15.428a2 2 0 00-1.022-.547l-2.387-.477a6 6 0 00-3.86.517l-.318.158a6 6 0 01-3.86.517L6.05 15.21a2 2 0 00-1.806.547M8 4h8l-1 1v5.172a2 2 0 00.586 1.414l5 5c1.26 1.26.367 3.414-1.415 3.414H4.828c-1.782 0-2.674-2.154-1.414-3.414l5-5A2 2 0 009 10.172V5L8 4z",
+                        on_click: move |_| mobile_open.set(false),
+                    }
 
                     div {
                         class: "mt-6 mb-3 px-3",

--- a/ferrite-dashboard/src/main.rs
+++ b/ferrite-dashboard/src/main.rs
@@ -25,6 +25,10 @@ pub enum Route {
         DeviceDetail { id: String },
         #[route("/faults")]
         Faults {},
+        #[route("/crashes")]
+        Crashes {},
+        #[route("/crashes/:id")]
+        CrashDetail { id: String },
         #[route("/metrics")]
         Metrics {},
         #[route("/fleet")]
@@ -112,6 +116,18 @@ fn DeviceDetail(id: String) -> Element {
 #[component]
 fn Faults() -> Element {
     rsx! { FaultsPage {} }
+}
+
+/// Crashes list page route handler.
+#[component]
+fn Crashes() -> Element {
+    rsx! { CrashesPage {} }
+}
+
+/// Crash detail page route handler.
+#[component]
+fn CrashDetail(id: String) -> Element {
+    rsx! { CrashDetailPage { id: id } }
 }
 
 /// Metrics overview page route handler.

--- a/ferrite-dashboard/src/pages/crashes.rs
+++ b/ferrite-dashboard/src/pages/crashes.rs
@@ -1,0 +1,265 @@
+use crate::api::types::*;
+use crate::auth::AuthState;
+use crate::components::{ErrorDisplay, Loading};
+use crate::Route;
+use dioxus::prelude::*;
+
+#[component]
+pub fn CrashesPage() -> Element {
+    let auth_state = use_context::<Signal<AuthState>>();
+    let poll_tick = crate::hooks::use_poll_tick();
+
+    let crashes_resource = use_resource(move || async move {
+        let _tick = poll_tick();
+        let client = crate::api::client::authenticated_client(&auth_state());
+        client.list_crash_groups().await
+    });
+
+    let binding = crashes_resource.read();
+    match &*binding {
+        None => rsx! { Loading {} },
+        Some(Err(e)) => rsx! { ErrorDisplay { message: e.to_string() } },
+        Some(Ok(groups)) => {
+            let total_occurrences: i64 = groups.iter().map(|g| g.occurrence_count).sum();
+            let total_devices: i64 = groups
+                .iter()
+                .map(|g| g.affected_device_count)
+                .max()
+                .unwrap_or(0);
+
+            rsx! {
+                div {
+                    class: "p-6 lg:p-8 max-w-[1400px] mx-auto",
+                    div {
+                        class: "mb-6 animate-fade-in",
+                        h1 {
+                            class: "text-2xl font-semibold text-gray-100",
+                            "Crash Analytics"
+                        }
+                        p {
+                            class: "mt-1 text-sm text-gray-500",
+                            "Faults grouped by crash signature (PC + fault type)"
+                        }
+                    }
+
+                    // Summary cards
+                    div {
+                        class: "grid grid-cols-1 sm:grid-cols-3 gap-4 mb-6",
+                        StatCard { label: "Crash Groups", value: format!("{}", groups.len()), color: "ferrite" }
+                        StatCard { label: "Total Occurrences", value: format!("{}", total_occurrences), color: "red" }
+                        StatCard { label: "Devices Affected", value: format!("{}", total_devices), color: "amber" }
+                    }
+
+                    if groups.is_empty() {
+                        div {
+                            class: "bg-surface-900 rounded-xl border border-surface-700 p-12 text-center",
+                            p {
+                                class: "text-gray-500 text-sm",
+                                "No crashes recorded"
+                            }
+                        }
+                    } else {
+                        div {
+                            class: "space-y-3",
+                            for group in groups {
+                                CrashGroupCard { group: group.clone() }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[component]
+fn StatCard(label: String, value: String, color: String) -> Element {
+    let bg = format!("bg-{}-500/5", color);
+    let border = format!("border-{}-500/20", color);
+    let text = format!("text-{}-400", color);
+
+    rsx! {
+        div {
+            class: "rounded-xl border p-4 {bg} {border}",
+            p {
+                class: "text-[10px] font-mono uppercase tracking-wider text-gray-500 mb-1",
+                "{label}"
+            }
+            p {
+                class: "text-2xl font-semibold font-mono {text}",
+                "{value}"
+            }
+        }
+    }
+}
+
+#[component]
+fn CrashGroupCard(group: CrashGroup) -> Element {
+    let type_name = group.fault_type_name();
+    let pc_hex = format!("0x{:08X}", group.pc);
+    let title = group.title.as_deref().unwrap_or("unknown symbol");
+
+    let (severity_bg, severity_border, severity_dot) = match group.fault_type {
+        0 => ("bg-red-500/5", "border-red-500/20", "bg-red-500"),
+        1 | 2 => ("bg-amber-500/5", "border-amber-500/20", "bg-amber-500"),
+        _ => ("bg-blue-500/5", "border-blue-500/20", "bg-blue-500"),
+    };
+
+    rsx! {
+        Link {
+            to: Route::CrashDetail { id: group.id.to_string() },
+            class: "block bg-surface-900 rounded-xl border {severity_border} p-5 {severity_bg} hover:bg-surface-850 transition-colors cursor-pointer",
+            div {
+                class: "flex items-start space-x-4",
+                div {
+                    class: "flex-shrink-0 mt-1",
+                    div { class: "h-2.5 w-2.5 rounded-full {severity_dot}" }
+                }
+                div {
+                    class: "flex-1 min-w-0",
+                    div {
+                        class: "flex items-center justify-between",
+                        div {
+                            class: "flex items-center space-x-2",
+                            h3 {
+                                class: "text-sm font-mono font-semibold text-gray-100",
+                                "{title}"
+                            }
+                            span {
+                                class: "text-[10px] font-mono text-gray-500",
+                                "{type_name} at {pc_hex}"
+                            }
+                        }
+                        div {
+                            class: "flex items-center space-x-3",
+                            span {
+                                class: "inline-flex items-center px-2 py-0.5 rounded text-xs font-mono font-medium bg-red-500/10 text-red-400 border border-red-500/20",
+                                "{group.occurrence_count}x"
+                            }
+                            span {
+                                class: "text-[10px] text-gray-600 font-mono",
+                                "{group.affected_device_count} device(s)"
+                            }
+                        }
+                    }
+                    div {
+                        class: "mt-2 flex items-center space-x-4 text-xs text-gray-500 font-mono",
+                        span { "First: {group.first_seen}" }
+                        span { "Last: {group.last_seen}" }
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Crash group detail page — shows individual fault occurrences.
+#[component]
+pub fn CrashDetailPage(id: String) -> Element {
+    let auth_state = use_context::<Signal<AuthState>>();
+    let group_id: i64 = id.parse().unwrap_or(0);
+
+    let detail_resource = use_resource(move || async move {
+        let client = crate::api::client::authenticated_client(&auth_state());
+        client.get_crash_group(group_id).await
+    });
+
+    let binding = detail_resource.read();
+    match &*binding {
+        None => rsx! { Loading {} },
+        Some(Err(e)) => rsx! { ErrorDisplay { message: e.to_string() } },
+        Some(Ok((group, occurrences))) => {
+            let type_name = group.fault_type_name();
+            let pc_hex = format!("0x{:08X}", group.pc);
+            let title = group.title.as_deref().unwrap_or("unknown symbol");
+
+            rsx! {
+                div {
+                    class: "p-6 lg:p-8 max-w-[1400px] mx-auto",
+                    // Back link
+                    div {
+                        class: "mb-4",
+                        Link {
+                            to: Route::Crashes {},
+                            class: "text-sm text-gray-500 hover:text-ferrite-400 transition-colors",
+                            "← Back to Crash Analytics"
+                        }
+                    }
+
+                    // Header
+                    div {
+                        class: "mb-6 animate-fade-in",
+                        h1 {
+                            class: "text-2xl font-semibold text-gray-100 font-mono",
+                            "{title}"
+                        }
+                        p {
+                            class: "mt-1 text-sm text-gray-500 font-mono",
+                            "{type_name} at {pc_hex}"
+                        }
+                    }
+
+                    // Stats
+                    div {
+                        class: "grid grid-cols-1 sm:grid-cols-4 gap-4 mb-6",
+                        StatCard { label: "Occurrences", value: format!("{}", group.occurrence_count), color: "red" }
+                        StatCard { label: "Devices Affected", value: format!("{}", group.affected_device_count), color: "amber" }
+                        StatCard { label: "First Seen", value: group.first_seen.clone(), color: "blue" }
+                        StatCard { label: "Last Seen", value: group.last_seen.clone(), color: "ferrite" }
+                    }
+
+                    // Occurrences
+                    div {
+                        class: "mb-4",
+                        p {
+                            class: "text-[10px] text-gray-600 font-mono uppercase tracking-wider",
+                            "{occurrences.len()} occurrence(s)"
+                        }
+                    }
+
+                    div {
+                        class: "space-y-3",
+                        for fault in occurrences {
+                            OccurrenceCard { fault: fault.clone() }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[component]
+fn OccurrenceCard(fault: FaultEvent) -> Element {
+    let pc_hex = format!("0x{:08X}", fault.pc);
+    let lr_hex = format!("0x{:08X}", fault.lr);
+    let symbol = fault.symbol.as_deref().unwrap_or("unknown");
+
+    rsx! {
+        div {
+            class: "bg-surface-900 rounded-xl border border-surface-700 p-4",
+            div {
+                class: "flex items-center justify-between mb-2",
+                div {
+                    class: "flex items-center space-x-2",
+                    span {
+                        class: "text-sm font-mono font-medium text-gray-200",
+                        "{fault.device_id}"
+                    }
+                    span {
+                        class: "text-[10px] font-mono text-gray-500",
+                        "PC {pc_hex} | LR {lr_hex}"
+                    }
+                }
+                span {
+                    class: "text-[10px] text-gray-600 font-mono",
+                    "{fault.created_at}"
+                }
+            }
+            p {
+                class: "text-xs text-gray-400 font-mono",
+                "Symbol: {symbol}"
+            }
+        }
+    }
+}

--- a/ferrite-dashboard/src/pages/mod.rs
+++ b/ferrite-dashboard/src/pages/mod.rs
@@ -1,5 +1,6 @@
 pub mod callback;
 pub mod compare;
+pub mod crashes;
 pub mod dashboard;
 pub mod device_detail;
 pub mod devices;
@@ -12,6 +13,7 @@ pub mod settings;
 
 pub use callback::CallbackPage;
 pub use compare::ComparePage;
+pub use crashes::{CrashDetailPage, CrashesPage};
 pub use dashboard::DashboardPage;
 pub use device_detail::DeviceDetailPage;
 pub use devices::DevicesPage;

--- a/ferrite-server/src/crashes.rs
+++ b/ferrite-server/src/crashes.rs
@@ -1,0 +1,100 @@
+//! Crash deduplication and analytics endpoints.
+//!
+//! Provides crash group listing and detail views for fault analysis.
+
+use axum::{
+    extract::{Path, State},
+    http::StatusCode,
+    response::IntoResponse,
+    Json,
+};
+use serde::Deserialize;
+use std::sync::Arc;
+
+use crate::AppState;
+
+/// Pagination query parameters for crash group endpoints.
+#[derive(Debug, Deserialize)]
+pub struct CrashListParams {
+    /// Maximum number of results (default 100, max 1000).
+    limit: Option<usize>,
+    /// Offset for pagination (default 0).
+    offset: Option<usize>,
+}
+
+impl CrashListParams {
+    fn limit(&self) -> usize {
+        self.limit.unwrap_or(100).min(1000)
+    }
+    fn offset(&self) -> usize {
+        self.offset.unwrap_or(0)
+    }
+}
+
+/// GET /crashes — list crash groups ordered by occurrence count.
+pub async fn list_crash_groups(
+    State(state): State<Arc<AppState>>,
+    axum::extract::Query(params): axum::extract::Query<CrashListParams>,
+) -> impl IntoResponse {
+    let store = state.store.lock().await;
+    let groups = match store.list_crash_groups(params.limit(), params.offset()) {
+        Ok(g) => g,
+        Err(e) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({ "error": e.to_string() })),
+            );
+        }
+    };
+    let total = match store.count_crash_groups() {
+        Ok(n) => n,
+        Err(e) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({ "error": e.to_string() })),
+            );
+        }
+    };
+    (
+        StatusCode::OK,
+        Json(serde_json::json!({ "crash_groups": groups, "total": total })),
+    )
+}
+
+/// GET /crashes/:id — get crash group detail with paginated occurrences.
+pub async fn get_crash_group_detail(
+    State(state): State<Arc<AppState>>,
+    Path(id): Path<i64>,
+    axum::extract::Query(params): axum::extract::Query<CrashListParams>,
+) -> impl IntoResponse {
+    let store = state.store.lock().await;
+    let group = match store.get_crash_group(id) {
+        Ok(Some(g)) => g,
+        Ok(None) => {
+            return (
+                StatusCode::NOT_FOUND,
+                Json(serde_json::json!({ "error": "crash group not found" })),
+            );
+        }
+        Err(e) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({ "error": e.to_string() })),
+            );
+        }
+    };
+    let occurrences =
+        match store.list_faults_for_crash_group(id, params.limit(), params.offset()) {
+            Ok(f) => f,
+            Err(e) => {
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(serde_json::json!({ "error": e.to_string() })),
+                );
+            }
+        };
+    (
+        StatusCode::OK,
+        Json(serde_json::json!({ "group": group, "occurrences": occurrences })),
+    )
+}

--- a/ferrite-server/src/crashes.rs
+++ b/ferrite-server/src/crashes.rs
@@ -83,16 +83,15 @@ pub async fn get_crash_group_detail(
             );
         }
     };
-    let occurrences =
-        match store.list_faults_for_crash_group(id, params.limit(), params.offset()) {
-            Ok(f) => f,
-            Err(e) => {
-                return (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    Json(serde_json::json!({ "error": e.to_string() })),
-                );
-            }
-        };
+    let occurrences = match store.list_faults_for_crash_group(id, params.limit(), params.offset()) {
+        Ok(f) => f,
+        Err(e) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({ "error": e.to_string() })),
+            );
+        }
+    };
     (
         StatusCode::OK,
         Json(serde_json::json!({ "group": group, "occurrences": occurrences })),

--- a/ferrite-server/src/ingest.rs
+++ b/ferrite-server/src/ingest.rs
@@ -677,6 +677,20 @@ async fn ingest_chunks(
                         sym.symbolize(fault.pc).await.ok().flatten()
                     };
 
+                    // Find or create crash group for deduplication.
+                    let crash_group_id = match store.find_or_create_crash_group(
+                        fault.fault_type,
+                        fault.pc,
+                        symbol.as_deref(),
+                        dev_rid,
+                    ) {
+                        Ok(id) => Some(id),
+                        Err(e) => {
+                            errors.push(format!("db error upserting crash group: {e}"));
+                            None
+                        }
+                    };
+
                     if let Err(e) = store.insert_fault(
                         dev_rid,
                         fault.fault_type,
@@ -689,9 +703,16 @@ async fn ingest_chunks(
                         fault.sp,
                         &fault.stack_snapshot,
                         symbol.as_deref(),
+                        crash_group_id,
                     ) {
                         errors.push(format!("db error inserting fault: {e}"));
                     } else {
+                        // Update affected device count for the crash group.
+                        if let Some(cg_id) = crash_group_id {
+                            if let Err(e) = store.update_crash_group_device_count(cg_id) {
+                                errors.push(format!("db error updating crash group device count: {e}"));
+                            }
+                        }
                         let _ = state.event_tx.send(SsePayload::fault(
                             &current_device_id,
                             fault.fault_type,
@@ -1335,6 +1356,8 @@ pub fn router(state: Arc<AppState>) -> Router {
         .route("/devices/:id/faults", get(list_device_faults))
         .route("/devices/:id/metrics", get(list_device_metrics))
         .route("/faults", get(list_all_faults))
+        .route("/crashes", get(crate::crashes::list_crash_groups))
+        .route("/crashes/:id", get(crate::crashes::get_crash_group_detail))
         .route("/metrics", get(list_all_metrics))
         // SSE live event stream (#26)
         .route("/events/stream", get(crate::sse::event_stream))

--- a/ferrite-server/src/ingest.rs
+++ b/ferrite-server/src/ingest.rs
@@ -710,7 +710,9 @@ async fn ingest_chunks(
                         // Update affected device count for the crash group.
                         if let Some(cg_id) = crash_group_id {
                             if let Err(e) = store.update_crash_group_device_count(cg_id) {
-                                errors.push(format!("db error updating crash group device count: {e}"));
+                                errors.push(format!(
+                                    "db error updating crash group device count: {e}"
+                                ));
                             }
                         }
                         let _ = state.event_tx.send(SsePayload::fault(

--- a/ferrite-server/src/lib.rs
+++ b/ferrite-server/src/lib.rs
@@ -3,6 +3,7 @@ pub mod auth;
 pub mod auth_middleware;
 pub mod backup;
 pub mod config;
+pub mod crashes;
 pub mod groups;
 pub mod ingest;
 pub mod ota;

--- a/ferrite-server/src/store.rs
+++ b/ferrite-server/src/store.rs
@@ -36,6 +36,21 @@ pub struct FaultEvent {
     pub stack_snapshot: String,
     pub symbol: Option<String>,
     pub created_at: String,
+    pub crash_group_id: Option<i64>,
+}
+
+/// A crash group that deduplicates faults by signature (fault_type + PC).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CrashGroup {
+    pub id: i64,
+    pub signature_hash: String,
+    pub pc: u32,
+    pub fault_type: u8,
+    pub first_seen: String,
+    pub last_seen: String,
+    pub occurrence_count: i64,
+    pub affected_device_count: i64,
+    pub title: Option<String>,
 }
 
 /// A stored metric row.
@@ -185,6 +200,19 @@ impl Store {
                 added_at    TEXT NOT NULL DEFAULT (datetime('now')),
                 PRIMARY KEY (group_id, device_id)
             );
+
+            CREATE TABLE IF NOT EXISTS crash_groups (
+                id                    INTEGER PRIMARY KEY AUTOINCREMENT,
+                signature_hash        TEXT NOT NULL UNIQUE,
+                pc                    INTEGER NOT NULL,
+                fault_type            INTEGER NOT NULL,
+                first_seen            TEXT NOT NULL DEFAULT (datetime('now')),
+                last_seen             TEXT NOT NULL DEFAULT (datetime('now')),
+                occurrence_count      INTEGER NOT NULL DEFAULT 1,
+                affected_device_count INTEGER NOT NULL DEFAULT 1,
+                title                 TEXT
+            );
+            CREATE INDEX IF NOT EXISTS idx_crash_groups_count ON crash_groups(occurrence_count DESC);
             ",
         )?;
         Ok(())
@@ -199,6 +227,7 @@ impl Store {
             "ALTER TABLE devices ADD COLUMN tags TEXT",
             "ALTER TABLE devices ADD COLUMN provisioned_by TEXT",
             "ALTER TABLE devices ADD COLUMN provisioned_at TEXT",
+            "ALTER TABLE fault_events ADD COLUMN crash_group_id INTEGER REFERENCES crash_groups(id)",
         ];
         for sql in &columns {
             let _ = self.conn.execute(sql, []);
@@ -423,12 +452,13 @@ impl Store {
         sp: u32,
         stack_snapshot: &[u32],
         symbol: Option<&str>,
+        crash_group_id: Option<i64>,
     ) -> SqlResult<i64> {
         let snapshot_json = serde_json::to_string(stack_snapshot).unwrap_or_else(|_| "[]".into());
         self.conn.execute(
             "INSERT INTO fault_events
-             (device_rowid, fault_type, pc, lr, cfsr, hfsr, mmfar, bfar, sp, stack_snapshot, symbol)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)",
+             (device_rowid, fault_type, pc, lr, cfsr, hfsr, mmfar, bfar, sp, stack_snapshot, symbol, crash_group_id)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)",
             params![
                 device_rowid,
                 fault_type as i64,
@@ -441,9 +471,30 @@ impl Store {
                 sp as i64,
                 snapshot_json,
                 symbol,
+                crash_group_id,
             ],
         )?;
         Ok(self.conn.last_insert_rowid())
+    }
+
+    fn fault_from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<FaultEvent> {
+        Ok(FaultEvent {
+            id: row.get(0)?,
+            device_rowid: row.get(1)?,
+            device_id: row.get(2)?,
+            fault_type: row.get::<_, i64>(3)? as u8,
+            pc: row.get::<_, i64>(4)? as u32,
+            lr: row.get::<_, i64>(5)? as u32,
+            cfsr: row.get::<_, i64>(6)? as u32,
+            hfsr: row.get::<_, i64>(7)? as u32,
+            mmfar: row.get::<_, i64>(8)? as u32,
+            bfar: row.get::<_, i64>(9)? as u32,
+            sp: row.get::<_, i64>(10)? as u32,
+            stack_snapshot: row.get(11)?,
+            symbol: row.get(12)?,
+            created_at: row.get(13)?,
+            crash_group_id: row.get(14)?,
+        })
     }
 
     pub fn list_faults_for_device(&self, device_id: &str) -> SqlResult<Vec<FaultEvent>> {
@@ -460,7 +511,7 @@ impl Store {
     ) -> SqlResult<Vec<FaultEvent>> {
         let mut sql = String::from(
             "SELECT f.id, f.device_rowid, d.device_id, f.fault_type, f.pc, f.lr,
-                    f.cfsr, f.hfsr, f.mmfar, f.bfar, f.sp, f.stack_snapshot, f.symbol, f.created_at
+                    f.cfsr, f.hfsr, f.mmfar, f.bfar, f.sp, f.stack_snapshot, f.symbol, f.created_at, f.crash_group_id
              FROM fault_events f
              JOIN devices d ON d.id = f.device_rowid
              WHERE d.device_id = ?1",
@@ -486,24 +537,7 @@ impl Store {
         let params_ref: Vec<&dyn rusqlite::types::ToSql> =
             param_values.iter().map(|p| p.as_ref()).collect();
         let mut stmt = self.conn.prepare(&sql)?;
-        let rows = stmt.query_map(params_ref.as_slice(), |row| {
-            Ok(FaultEvent {
-                id: row.get(0)?,
-                device_rowid: row.get(1)?,
-                device_id: row.get(2)?,
-                fault_type: row.get::<_, i64>(3)? as u8,
-                pc: row.get::<_, i64>(4)? as u32,
-                lr: row.get::<_, i64>(5)? as u32,
-                cfsr: row.get::<_, i64>(6)? as u32,
-                hfsr: row.get::<_, i64>(7)? as u32,
-                mmfar: row.get::<_, i64>(8)? as u32,
-                bfar: row.get::<_, i64>(9)? as u32,
-                sp: row.get::<_, i64>(10)? as u32,
-                stack_snapshot: row.get(11)?,
-                symbol: row.get(12)?,
-                created_at: row.get(13)?,
-            })
-        })?;
+        let rows = stmt.query_map(params_ref.as_slice(), Self::fault_from_row)?;
         rows.collect()
     }
 
@@ -520,7 +554,7 @@ impl Store {
     ) -> SqlResult<Vec<FaultEvent>> {
         let mut sql = String::from(
             "SELECT f.id, f.device_rowid, d.device_id, f.fault_type, f.pc, f.lr,
-                    f.cfsr, f.hfsr, f.mmfar, f.bfar, f.sp, f.stack_snapshot, f.symbol, f.created_at
+                    f.cfsr, f.hfsr, f.mmfar, f.bfar, f.sp, f.stack_snapshot, f.symbol, f.created_at, f.crash_group_id
              FROM fault_events f
              JOIN devices d ON d.id = f.device_rowid
              WHERE 1=1",
@@ -545,25 +579,137 @@ impl Store {
         let params_ref: Vec<&dyn rusqlite::types::ToSql> =
             param_values.iter().map(|p| p.as_ref()).collect();
         let mut stmt = self.conn.prepare(&sql)?;
-        let rows = stmt.query_map(params_ref.as_slice(), |row| {
-            Ok(FaultEvent {
+        let rows = stmt.query_map(params_ref.as_slice(), Self::fault_from_row)?;
+        rows.collect()
+    }
+
+    // ---- Crash groups ----
+
+    /// Compute a deterministic signature hash from fault_type and PC.
+    fn compute_signature_hash(fault_type: u8, pc: u32) -> String {
+        format!("{:02x}{:08x}", fault_type, pc)
+    }
+
+    /// Find or create a crash group for the given fault signature.
+    /// Upserts the crash group and returns its id.
+    pub fn find_or_create_crash_group(
+        &self,
+        fault_type: u8,
+        pc: u32,
+        title: Option<&str>,
+        _device_rowid: i64,
+    ) -> SqlResult<i64> {
+        let sig = Self::compute_signature_hash(fault_type, pc);
+        self.conn.execute(
+            "INSERT INTO crash_groups (signature_hash, pc, fault_type, title)
+             VALUES (?1, ?2, ?3, ?4)
+             ON CONFLICT(signature_hash) DO UPDATE SET
+                last_seen = datetime('now'),
+                occurrence_count = crash_groups.occurrence_count + 1,
+                title = COALESCE(?4, crash_groups.title)",
+            params![sig, pc as i64, fault_type as i64, title],
+        )?;
+        let id: i64 = self.conn.query_row(
+            "SELECT id FROM crash_groups WHERE signature_hash = ?1",
+            params![sig],
+            |row| row.get(0),
+        )?;
+        Ok(id)
+    }
+
+    /// Update the affected_device_count for a crash group based on distinct devices in fault_events.
+    pub fn update_crash_group_device_count(&self, crash_group_id: i64) -> SqlResult<()> {
+        self.conn.execute(
+            "UPDATE crash_groups SET affected_device_count = (
+                SELECT COUNT(DISTINCT device_rowid) FROM fault_events WHERE crash_group_id = ?1
+             ) WHERE id = ?1",
+            params![crash_group_id],
+        )?;
+        Ok(())
+    }
+
+    /// List crash groups ordered by occurrence_count descending.
+    pub fn list_crash_groups(&self, limit: usize, offset: usize) -> SqlResult<Vec<CrashGroup>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT id, signature_hash, pc, fault_type, first_seen, last_seen,
+                    occurrence_count, affected_device_count, title
+             FROM crash_groups
+             ORDER BY occurrence_count DESC
+             LIMIT ?1 OFFSET ?2",
+        )?;
+        let rows = stmt.query_map(params![limit as i64, offset as i64], |row| {
+            Ok(CrashGroup {
                 id: row.get(0)?,
-                device_rowid: row.get(1)?,
-                device_id: row.get(2)?,
+                signature_hash: row.get(1)?,
+                pc: row.get::<_, i64>(2)? as u32,
                 fault_type: row.get::<_, i64>(3)? as u8,
-                pc: row.get::<_, i64>(4)? as u32,
-                lr: row.get::<_, i64>(5)? as u32,
-                cfsr: row.get::<_, i64>(6)? as u32,
-                hfsr: row.get::<_, i64>(7)? as u32,
-                mmfar: row.get::<_, i64>(8)? as u32,
-                bfar: row.get::<_, i64>(9)? as u32,
-                sp: row.get::<_, i64>(10)? as u32,
-                stack_snapshot: row.get(11)?,
-                symbol: row.get(12)?,
-                created_at: row.get(13)?,
+                first_seen: row.get(4)?,
+                last_seen: row.get(5)?,
+                occurrence_count: row.get(6)?,
+                affected_device_count: row.get(7)?,
+                title: row.get(8)?,
             })
         })?;
         rows.collect()
+    }
+
+    /// Get a single crash group by id.
+    pub fn get_crash_group(&self, id: i64) -> SqlResult<Option<CrashGroup>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT id, signature_hash, pc, fault_type, first_seen, last_seen,
+                    occurrence_count, affected_device_count, title
+             FROM crash_groups
+             WHERE id = ?1",
+        )?;
+        let mut rows = stmt.query_map(params![id], |row| {
+            Ok(CrashGroup {
+                id: row.get(0)?,
+                signature_hash: row.get(1)?,
+                pc: row.get::<_, i64>(2)? as u32,
+                fault_type: row.get::<_, i64>(3)? as u8,
+                first_seen: row.get(4)?,
+                last_seen: row.get(5)?,
+                occurrence_count: row.get(6)?,
+                affected_device_count: row.get(7)?,
+                title: row.get(8)?,
+            })
+        })?;
+        match rows.next() {
+            Some(r) => Ok(Some(r?)),
+            None => Ok(None),
+        }
+    }
+
+    /// List fault events belonging to a specific crash group.
+    pub fn list_faults_for_crash_group(
+        &self,
+        crash_group_id: i64,
+        limit: usize,
+        offset: usize,
+    ) -> SqlResult<Vec<FaultEvent>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT f.id, f.device_rowid, d.device_id, f.fault_type, f.pc, f.lr,
+                    f.cfsr, f.hfsr, f.mmfar, f.bfar, f.sp, f.stack_snapshot, f.symbol, f.created_at, f.crash_group_id
+             FROM fault_events f
+             JOIN devices d ON d.id = f.device_rowid
+             WHERE f.crash_group_id = ?1
+             ORDER BY f.created_at DESC
+             LIMIT ?2 OFFSET ?3",
+        )?;
+        let rows = stmt.query_map(
+            params![crash_group_id, limit as i64, offset as i64],
+            Self::fault_from_row,
+        )?;
+        rows.collect()
+    }
+
+    /// Count total number of crash groups.
+    pub fn count_crash_groups(&self) -> SqlResult<i64> {
+        self.conn.query_row(
+            "SELECT COUNT(*) FROM crash_groups",
+            [],
+            |row| row.get(0),
+        )
     }
 
     // ---- Metrics ----
@@ -1158,6 +1304,7 @@ mod tests {
                 0x2000_3F00,
                 &[0xDEAD; 4],
                 Some("main+0x20"),
+                None,
             )
             .unwrap();
         assert!(f1 > 0);
@@ -1207,7 +1354,7 @@ mod tests {
         assert_eq!(store.count_reboots_for_device(dev).unwrap(), 0);
 
         store
-            .insert_fault(dev, 0, 0, 0, 0, 0, 0, 0, 0, &[], None)
+            .insert_fault(dev, 0, 0, 0, 0, 0, 0, 0, 0, &[], None, None)
             .unwrap();
         store.insert_metric(dev, "k", 0, "{}", 0).unwrap();
         store.insert_reboot(dev, 1, 0, 1, 0).unwrap();
@@ -1224,7 +1371,7 @@ mod tests {
 
         for _ in 0..5 {
             store
-                .insert_fault(dev, 0, 0, 0, 0, 0, 0, 0, 0, &[], None)
+                .insert_fault(dev, 0, 0, 0, 0, 0, 0, 0, 0, &[], None, None)
                 .unwrap();
         }
 
@@ -1325,7 +1472,7 @@ mod tests {
 
         let dev = store.upsert_device("dev-001", "1.0.0", 1).unwrap();
         store
-            .insert_fault(dev, 0, 0, 0, 0, 0, 0, 0, 0, &[], None)
+            .insert_fault(dev, 0, 0, 0, 0, 0, 0, 0, 0, &[], None, None)
             .unwrap();
         store.insert_metric(dev, "k", 0, "{}", 0).unwrap();
         store.insert_reboot(dev, 1, 0, 1, 0).unwrap();
@@ -1347,7 +1494,7 @@ mod tests {
         // Insert some data
         store.insert_metric(dev, "old", 0, "{}", 0).unwrap();
         store
-            .insert_fault(dev, 0, 0, 0, 0, 0, 0, 0, 0, &[], None)
+            .insert_fault(dev, 0, 0, 0, 0, 0, 0, 0, 0, &[], None, None)
             .unwrap();
         store.insert_reboot(dev, 1, 0, 1, 0).unwrap();
 
@@ -1422,5 +1569,78 @@ mod tests {
         assert!(store.delete_ota_target("dev-001").unwrap());
         assert!(!store.delete_ota_target("dev-001").unwrap()); // already gone
         assert!(store.list_ota_targets().unwrap().is_empty());
+    }
+
+    // ---- Crash group tests ----
+
+    #[test]
+    fn test_crash_group_deduplication() {
+        let store = Store::open_in_memory().unwrap();
+        let dev = store.upsert_device("dev-001", "1.0.0", 1).unwrap();
+
+        // Insert two faults with the same PC and fault_type.
+        let cg1 = store
+            .find_or_create_crash_group(3, 0x0800_2000, Some("HardFault at main+0x20"), dev)
+            .unwrap();
+        store
+            .insert_fault(dev, 3, 0x0800_2000, 0, 0, 0, 0, 0, 0, &[], None, Some(cg1))
+            .unwrap();
+
+        let cg2 = store
+            .find_or_create_crash_group(3, 0x0800_2000, None, dev)
+            .unwrap();
+        store
+            .insert_fault(dev, 3, 0x0800_2000, 0, 0, 0, 0, 0, 0, &[], None, Some(cg2))
+            .unwrap();
+
+        // Same crash group should be reused.
+        assert_eq!(cg1, cg2);
+
+        let group = store.get_crash_group(cg1).unwrap().unwrap();
+        assert_eq!(group.occurrence_count, 2);
+        assert_eq!(group.pc, 0x0800_2000);
+        assert_eq!(group.fault_type, 3);
+        // Title should be preserved from the first insert.
+        assert_eq!(group.title, Some("HardFault at main+0x20".to_string()));
+
+        // Only one crash group total.
+        assert_eq!(store.count_crash_groups().unwrap(), 1);
+
+        // List should return it.
+        let groups = store.list_crash_groups(100, 0).unwrap();
+        assert_eq!(groups.len(), 1);
+        assert_eq!(groups[0].occurrence_count, 2);
+    }
+
+    #[test]
+    fn test_crash_group_affected_devices() {
+        let store = Store::open_in_memory().unwrap();
+        let dev1 = store.upsert_device("dev-001", "1.0.0", 1).unwrap();
+        let dev2 = store.upsert_device("dev-002", "1.0.0", 1).unwrap();
+
+        // Insert faults from two different devices with the same signature.
+        let cg = store
+            .find_or_create_crash_group(3, 0x0800_3000, Some("UsageFault"), dev1)
+            .unwrap();
+        store
+            .insert_fault(dev1, 3, 0x0800_3000, 0, 0, 0, 0, 0, 0, &[], None, Some(cg))
+            .unwrap();
+        store.update_crash_group_device_count(cg).unwrap();
+
+        let _ = store
+            .find_or_create_crash_group(3, 0x0800_3000, None, dev2)
+            .unwrap();
+        store
+            .insert_fault(dev2, 3, 0x0800_3000, 0, 0, 0, 0, 0, 0, &[], None, Some(cg))
+            .unwrap();
+        store.update_crash_group_device_count(cg).unwrap();
+
+        let group = store.get_crash_group(cg).unwrap().unwrap();
+        assert_eq!(group.occurrence_count, 2);
+        assert_eq!(group.affected_device_count, 2);
+
+        // Verify faults for crash group.
+        let faults = store.list_faults_for_crash_group(cg, 100, 0).unwrap();
+        assert_eq!(faults.len(), 2);
     }
 }

--- a/ferrite-server/src/store.rs
+++ b/ferrite-server/src/store.rs
@@ -705,11 +705,8 @@ impl Store {
 
     /// Count total number of crash groups.
     pub fn count_crash_groups(&self) -> SqlResult<i64> {
-        self.conn.query_row(
-            "SELECT COUNT(*) FROM crash_groups",
-            [],
-            |row| row.get(0),
-        )
+        self.conn
+            .query_row("SELECT COUNT(*) FROM crash_groups", [], |row| row.get(0))
     }
 
     // ---- Metrics ----


### PR DESCRIPTION
## Summary

### ferrite-cli (new crate, 1000+ lines)
- `ferrite login` — saves credentials to `~/.ferrite/config.toml`
- `ferrite devices list/inspect/delete` — fleet management with table/json/csv output
- `ferrite faults list [--device] [--since]` — fault queries
- `ferrite groups list/create/add-device/remove-device/devices` — group management
- `ferrite metrics query --key <key> --since <duration>` — metric queries
- `ferrite ota deploy/status/list/cancel` — OTA target management
- Global `--server` and `--format` flags

### Crash deduplication (ferrite-server)
- New `crash_groups` table grouping faults by `(PC, fault_type)` signature
- Auto-assigns `crash_group_id` on fault ingest
- Tracks `occurrence_count` and `affected_device_count`
- `GET /crashes` — paginated crash group list sorted by occurrence count
- `GET /crashes/:id` — group detail with individual fault occurrences
- 2 new tests: dedup + multi-device counting (40/40 pass)

## Test plan
- [x] `cargo build -p ferrite-cli -p ferrite-server` compiles
- [x] `cargo test -p ferrite-server --lib` — 40/40 pass
- [x] `ferrite --help` shows full command tree
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)