### PR TITLE
feat: Sprint 2a — firmware artifact storage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,7 @@ COPY --from=builder --chown=ferrite:ferrite \
 COPY --from=builder --chown=ferrite:ferrite \
     /app/docker/entrypoint.sh ./entrypoint.sh
 
-RUN mkdir -p data elfs
+RUN mkdir -p data elfs firmware
 
 EXPOSE 4000
 ENV RUST_LOG=info

--- a/ferrite-server/Cargo.toml
+++ b/ferrite-server/Cargo.toml
@@ -35,6 +35,7 @@ jsonwebtoken = "9"
 tokio-stream = { version = "0.1", features = ["sync"] }
 aes = "0.8"
 ccm = "0.5"
+sha2 = "0.10"
 
 [dev-dependencies]
 tempfile = "3"

--- a/ferrite-server/src/ingest.rs
+++ b/ferrite-server/src/ingest.rs
@@ -1397,6 +1397,19 @@ pub fn router(state: Arc<AppState>) -> Router {
             "/ota/targets/:device_id",
             get(crate::ota::get_ota_target).delete(crate::ota::delete_ota_target),
         )
+        // OTA firmware artifact storage (#Sprint2a)
+        .route(
+            "/ota/firmware",
+            get(crate::ota::list_firmware).post(crate::ota::upload_firmware),
+        )
+        .route(
+            "/ota/firmware/:id",
+            get(crate::ota::get_firmware).delete(crate::ota::delete_firmware),
+        )
+        .route(
+            "/ota/firmware/:id/download",
+            get(crate::ota::download_firmware),
+        )
         // Admin: backup, retention, device management
         .route("/admin/backup", get(crate::backup::backup_database))
         .route("/admin/retention", get(crate::backup::retention_info))

--- a/ferrite-server/src/lib.rs
+++ b/ferrite-server/src/lib.rs
@@ -22,6 +22,7 @@ pub struct AppState {
     pub store: Mutex<store::Store>,
     pub symbolicator: Mutex<symbolicate::Symbolicator>,
     pub elf_dir: PathBuf,
+    pub firmware_dir: PathBuf,
     pub config: &'static config::AuthConfig,
     pub event_tx: broadcast::Sender<sse::SsePayload>,
     pub counters: prometheus::RequestCounters,

--- a/ferrite-server/src/main.rs
+++ b/ferrite-server/src/main.rs
@@ -31,6 +31,10 @@ struct Cli {
     #[arg(long, default_value = "./elfs")]
     elf_dir: PathBuf,
 
+    /// Directory for firmware artifacts (OTA binaries)
+    #[arg(long, default_value = "./firmware")]
+    firmware_dir: PathBuf,
+
     /// Directory containing dashboard static files (index.html + assets/).
     /// If set, the server serves the dashboard UI and API from the same origin.
     #[arg(long)]
@@ -71,8 +75,9 @@ async fn main() -> anyhow::Result<()> {
 
     let cli = Cli::parse();
 
-    // Ensure elf directory exists
+    // Ensure directories exist
     std::fs::create_dir_all(&cli.elf_dir)?;
+    std::fs::create_dir_all(&cli.firmware_dir)?;
 
     // Load auth config from environment (leaked for 'static lifetime)
     let config: &'static AuthConfig = Box::leak(Box::new(AuthConfig::from_env()));
@@ -98,6 +103,7 @@ async fn main() -> anyhow::Result<()> {
         store: Mutex::new(store),
         symbolicator: Mutex::new(symbolicator),
         elf_dir: cli.elf_dir.clone(),
+        firmware_dir: cli.firmware_dir.clone(),
         config,
         event_tx,
         counters: RequestCounters::new(),

--- a/ferrite-server/src/ota.rs
+++ b/ferrite-server/src/ota.rs
@@ -1,19 +1,22 @@
-//! OTA firmware target management API handlers.
+//! OTA firmware target management and firmware artifact storage.
 //!
-//! These endpoints let operators set target firmware versions per device.
-//! When a device sends an OtaRequest chunk, the server compares its build_id
-//! against the target and emits an SSE event if an update is available.
+//! Target endpoints let operators set target firmware versions per device.
+//! Firmware endpoints handle binary upload, listing, download, and deletion.
 
 use axum::{
-    extract::{Path, State},
+    extract::{DefaultBodyLimit, Path, State},
     http::StatusCode,
     response::IntoResponse,
     Json,
 };
 use serde::Deserialize;
+use sha2::{Digest, Sha256};
 use std::sync::Arc;
 
 use crate::AppState;
+
+/// Maximum firmware binary size (20 MB).
+const MAX_FIRMWARE_SIZE: usize = 20 * 1024 * 1024;
 
 #[derive(Deserialize)]
 pub struct SetOtaTargetRequest {
@@ -95,6 +98,203 @@ pub async fn delete_ota_target(
         Ok(false) => (
             StatusCode::NOT_FOUND,
             Json(serde_json::json!({ "error": "no OTA target for this device" })),
+        ),
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({ "error": e.to_string() })),
+        ),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Firmware artifact endpoints
+// ---------------------------------------------------------------------------
+
+/// POST /ota/firmware — upload a firmware binary.
+///
+/// Headers: X-Firmware-Version (required), X-Build-Id (optional), X-Signer (optional).
+/// Body: raw binary firmware data.
+pub async fn upload_firmware(
+    State(state): State<Arc<AppState>>,
+    headers: axum::http::HeaderMap,
+    body: axum::body::Bytes,
+) -> impl IntoResponse {
+    if body.len() > MAX_FIRMWARE_SIZE {
+        return (
+            StatusCode::PAYLOAD_TOO_LARGE,
+            Json(serde_json::json!({
+                "ok": false,
+                "error": format!(
+                    "firmware too large: {} bytes (max {})",
+                    body.len(),
+                    MAX_FIRMWARE_SIZE
+                ),
+            })),
+        );
+    }
+
+    if body.is_empty() {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({ "ok": false, "error": "empty body" })),
+        );
+    }
+
+    let version = headers
+        .get("X-Firmware-Version")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("unknown")
+        .to_string();
+
+    let build_id: i64 = headers
+        .get("X-Build-Id")
+        .and_then(|v| v.to_str().ok())
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(0);
+
+    let signer = headers
+        .get("X-Signer")
+        .and_then(|v| v.to_str().ok())
+        .map(|s| s.to_string());
+
+    let mut hasher = Sha256::new();
+    hasher.update(&body);
+    let sha256 = format!("{:x}", hasher.finalize());
+
+    let filename = format!("{}-b{}-{}.bin", version, build_id, &sha256[..8]);
+    let path = state.firmware_dir.join(&filename);
+
+    if let Err(e) = tokio::fs::write(&path, &body).await {
+        return (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({ "ok": false, "error": format!("failed to write file: {e}") })),
+        );
+    }
+
+    let store = state.store.lock().await;
+    match store.insert_firmware_artifact(
+        &version,
+        build_id,
+        &sha256,
+        body.len() as i64,
+        &filename,
+        signer.as_deref(),
+    ) {
+        Ok(artifact) => (
+            StatusCode::OK,
+            Json(serde_json::json!({ "ok": true, "artifact": artifact })),
+        ),
+        Err(e) => {
+            let _ = tokio::fs::remove_file(&path).await;
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({ "ok": false, "error": e.to_string() })),
+            )
+        }
+    }
+}
+
+/// GET /ota/firmware — list all firmware artifacts.
+pub async fn list_firmware(State(state): State<Arc<AppState>>) -> impl IntoResponse {
+    let store = state.store.lock().await;
+    match store.list_firmware_artifacts() {
+        Ok(artifacts) => (
+            StatusCode::OK,
+            Json(serde_json::json!({ "artifacts": artifacts })),
+        ),
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({ "error": e.to_string() })),
+        ),
+    }
+}
+
+/// GET /ota/firmware/:id — get firmware artifact metadata.
+pub async fn get_firmware(
+    State(state): State<Arc<AppState>>,
+    Path(id): Path<i64>,
+) -> impl IntoResponse {
+    let store = state.store.lock().await;
+    match store.get_firmware_artifact(id) {
+        Ok(Some(artifact)) => (
+            StatusCode::OK,
+            Json(serde_json::json!({ "artifact": artifact })),
+        ),
+        Ok(None) => (
+            StatusCode::NOT_FOUND,
+            Json(serde_json::json!({ "error": "firmware artifact not found" })),
+        ),
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({ "error": e.to_string() })),
+        ),
+    }
+}
+
+/// GET /ota/firmware/:id/download — download the firmware binary.
+pub async fn download_firmware(
+    State(state): State<Arc<AppState>>,
+    Path(id): Path<i64>,
+) -> axum::response::Response {
+    let store = state.store.lock().await;
+    let artifact = match store.get_firmware_artifact(id) {
+        Ok(Some(a)) => a,
+        Ok(None) => {
+            return axum::response::Response::builder()
+                .status(StatusCode::NOT_FOUND)
+                .body(axum::body::Body::from("not found"))
+                .unwrap();
+        }
+        Err(e) => {
+            return axum::response::Response::builder()
+                .status(StatusCode::INTERNAL_SERVER_ERROR)
+                .body(axum::body::Body::from(e.to_string()))
+                .unwrap();
+        }
+    };
+    drop(store);
+
+    let path = state.firmware_dir.join(&artifact.filename);
+    match tokio::fs::read(&path).await {
+        Ok(data) => axum::response::Response::builder()
+            .status(StatusCode::OK)
+            .header("Content-Type", "application/octet-stream")
+            .header(
+                "Content-Disposition",
+                format!("attachment; filename=\"{}\"", artifact.filename),
+            )
+            .header("X-Firmware-SHA256", &artifact.sha256)
+            .body(axum::body::Body::from(data))
+            .unwrap(),
+        Err(_) => axum::response::Response::builder()
+            .status(StatusCode::NOT_FOUND)
+            .body(axum::body::Body::from("firmware file missing from disk"))
+            .unwrap(),
+    }
+}
+
+/// DELETE /ota/firmware/:id — delete a firmware artifact.
+pub async fn delete_firmware(
+    State(state): State<Arc<AppState>>,
+    Path(id): Path<i64>,
+) -> impl IntoResponse {
+    let store = state.store.lock().await;
+    let filename = store
+        .get_firmware_artifact(id)
+        .ok()
+        .flatten()
+        .map(|a| a.filename.clone());
+
+    match store.delete_firmware_artifact(id) {
+        Ok(true) => {
+            if let Some(f) = filename {
+                let _ = tokio::fs::remove_file(state.firmware_dir.join(f)).await;
+            }
+            (StatusCode::OK, Json(serde_json::json!({ "ok": true })))
+        }
+        Ok(false) => (
+            StatusCode::NOT_FOUND,
+            Json(serde_json::json!({ "error": "firmware artifact not found" })),
         ),
         Err(e) => (
             StatusCode::INTERNAL_SERVER_ERROR,

--- a/ferrite-server/src/ota.rs
+++ b/ferrite-server/src/ota.rs
@@ -4,7 +4,7 @@
 //! Firmware endpoints handle binary upload, listing, download, and deletion.
 
 use axum::{
-    extract::{DefaultBodyLimit, Path, State},
+    extract::{Path, State},
     http::StatusCode,
     response::IntoResponse,
     Json,

--- a/ferrite-server/src/store.rs
+++ b/ferrite-server/src/store.rs
@@ -1,4 +1,4 @@
-use rusqlite::{params, Connection, Result as SqlResult};
+use rusqlite::{params, Connection, OptionalExtension, Result as SqlResult};
 use serde::{Deserialize, Serialize};
 use std::path::Path;
 
@@ -84,6 +84,19 @@ pub struct OtaTarget {
     pub target_version: String,
     pub target_build_id: i64,
     pub firmware_url: Option<String>,
+    pub created_at: String,
+}
+
+/// A firmware binary artifact stored on the server.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FirmwareArtifact {
+    pub id: i64,
+    pub version: String,
+    pub build_id: i64,
+    pub sha256: String,
+    pub size: i64,
+    pub filename: String,
+    pub signer: Option<String>,
     pub created_at: String,
 }
 
@@ -213,6 +226,17 @@ impl Store {
                 title                 TEXT
             );
             CREATE INDEX IF NOT EXISTS idx_crash_groups_count ON crash_groups(occurrence_count DESC);
+
+            CREATE TABLE IF NOT EXISTS firmware_artifacts (
+                id          INTEGER PRIMARY KEY AUTOINCREMENT,
+                version     TEXT NOT NULL,
+                build_id    INTEGER NOT NULL DEFAULT 0,
+                sha256      TEXT NOT NULL,
+                size        INTEGER NOT NULL,
+                filename    TEXT NOT NULL,
+                signer      TEXT,
+                created_at  TEXT NOT NULL DEFAULT (datetime('now'))
+            );
             ",
         )?;
         Ok(())
@@ -1037,6 +1061,91 @@ impl Store {
             "DELETE FROM ota_targets WHERE device_id = ?1",
             params![device_id],
         )?;
+        Ok(changed > 0)
+    }
+
+    // ---- Firmware Artifacts ----
+
+    pub fn insert_firmware_artifact(
+        &self,
+        version: &str,
+        build_id: i64,
+        sha256: &str,
+        size: i64,
+        filename: &str,
+        signer: Option<&str>,
+    ) -> SqlResult<FirmwareArtifact> {
+        self.conn.execute(
+            "INSERT INTO firmware_artifacts (version, build_id, sha256, size, filename, signer)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+            params![version, build_id, sha256, size, filename, signer],
+        )?;
+        let id = self.conn.last_insert_rowid();
+        self.conn.query_row(
+            "SELECT id, version, build_id, sha256, size, filename, signer, created_at
+             FROM firmware_artifacts WHERE id = ?1",
+            params![id],
+            |row| {
+                Ok(FirmwareArtifact {
+                    id: row.get(0)?,
+                    version: row.get(1)?,
+                    build_id: row.get(2)?,
+                    sha256: row.get(3)?,
+                    size: row.get(4)?,
+                    filename: row.get(5)?,
+                    signer: row.get(6)?,
+                    created_at: row.get(7)?,
+                })
+            },
+        )
+    }
+
+    pub fn list_firmware_artifacts(&self) -> SqlResult<Vec<FirmwareArtifact>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT id, version, build_id, sha256, size, filename, signer, created_at
+             FROM firmware_artifacts ORDER BY created_at DESC",
+        )?;
+        let rows = stmt.query_map([], |row| {
+            Ok(FirmwareArtifact {
+                id: row.get(0)?,
+                version: row.get(1)?,
+                build_id: row.get(2)?,
+                sha256: row.get(3)?,
+                size: row.get(4)?,
+                filename: row.get(5)?,
+                signer: row.get(6)?,
+                created_at: row.get(7)?,
+            })
+        })?;
+        rows.collect()
+    }
+
+    pub fn get_firmware_artifact(&self, id: i64) -> SqlResult<Option<FirmwareArtifact>> {
+        self.conn
+            .query_row(
+                "SELECT id, version, build_id, sha256, size, filename, signer, created_at
+                 FROM firmware_artifacts WHERE id = ?1",
+                params![id],
+                |row| {
+                    Ok(FirmwareArtifact {
+                        id: row.get(0)?,
+                        version: row.get(1)?,
+                        build_id: row.get(2)?,
+                        sha256: row.get(3)?,
+                        size: row.get(4)?,
+                        filename: row.get(5)?,
+                        signer: row.get(6)?,
+                        created_at: row.get(7)?,
+                    })
+                },
+            )
+            .optional()
+    }
+
+    pub fn delete_firmware_artifact(&self, id: i64) -> SqlResult<bool> {
+        let changed = self
+            .conn
+            .execute("DELETE FROM firmware_artifacts WHERE id = ?1", params![id])?;
         Ok(changed > 0)
     }
 

--- a/ferrite-server/tests/integration.rs
+++ b/ferrite-server/tests/integration.rs
@@ -78,7 +78,8 @@ async fn spawn_server_with_env(env_overrides: Vec<(&str, &str)>) -> String {
         let state = Arc::new(ferrite_server::AppState {
             store: Mutex::new(store),
             symbolicator: Mutex::new(symbolicator),
-            elf_dir,
+            elf_dir: elf_dir.clone(),
+            firmware_dir: elf_dir,
             config,
             event_tx,
             counters: ferrite_server::prometheus::RequestCounters::new(),


### PR DESCRIPTION
## Summary
- `POST /ota/firmware` — upload firmware binary (raw body + headers)
- `GET /ota/firmware` — list all artifacts with metadata
- `GET /ota/firmware/:id` — single artifact metadata
- `GET /ota/firmware/:id/download` — binary download with SHA-256 header
- `DELETE /ota/firmware/:id` — remove artifact + disk file
- New `firmware_artifacts` table with SHA-256, size, version, build_id, signer
- `--firmware-dir` CLI arg, Dockerfile creates `firmware/` directory

## Usage
```bash
# Upload
curl -X POST https://server/ota/firmware \
  -H "X-Firmware-Version: 1.2.0" \
  -H "X-Build-Id: 42" \
  -H "X-Signer: ci-pipeline" \
  --data-binary @firmware.bin

# List
curl https://server/ota/firmware

# Download
curl -O https://server/ota/firmware/1/download
```

## Test plan
- [x] 40/40 server tests pass
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)