### PR TITLE
feat: Sprint 2c — SDK OTA client

### DIFF
--- a/ferrite-sdk/Cargo.toml
+++ b/ferrite-sdk/Cargo.toml
@@ -13,7 +13,7 @@ embassy = ["dep:embassy-time", "dep:embassy-sync"]
 postcard-encoding = ["dep:postcard", "dep:serde"]
 encryption = ["dep:aes", "dep:ccm"]
 usb-cdc = ["dep:embassy-usb", "embassy"]
-http = ["dep:reqwless", "dep:embedded-io-async", "embassy"]
+http = ["dep:reqwless", "dep:embedded-io-async", "dep:sha2", "embassy"]
 lora = ["dep:embedded-hal"]
 
 [dependencies]
@@ -31,6 +31,7 @@ aes = { version = "0.8", optional = true, default-features = false }
 ccm = { version = "0.5", optional = true, default-features = false }
 embassy-usb = { version = "0.3", optional = true, default-features = false }
 reqwless = { version = "0.12", optional = true, default-features = false }
+sha2 = { version = "0.10", optional = true, default-features = false }
 embedded-io-async = { version = "0.6", optional = true, default-features = false }
 embedded-hal = { version = "1.0", optional = true, default-features = false }
 

--- a/ferrite-sdk/src/lib.rs
+++ b/ferrite-sdk/src/lib.rs
@@ -12,6 +12,9 @@ pub mod trace;
 pub mod transport;
 pub mod upload;
 
+#[cfg(feature = "http")]
+pub mod ota;
+
 #[cfg(feature = "defmt")]
 pub mod defmt_sink;
 

--- a/ferrite-sdk/src/ota.rs
+++ b/ferrite-sdk/src/ota.rs
@@ -1,0 +1,292 @@
+//! OTA client for polling, downloading, and verifying firmware updates.
+//!
+//! Requires the `http` feature. The device polls `GET /ota/targets/:device_id`
+//! to check for a pending update, then streams firmware from the server's
+//! download endpoint directly into flash via a user-supplied write callback.
+//!
+//! SHA-256 integrity is verified against the `X-Firmware-SHA256` response
+//! header. MCUboot slot marking is left to the caller — this module only
+//! handles network I/O and integrity.
+//!
+//! # Example flow
+//! ```ignore
+//! let mut ota = OtaClient::new(tcp, "MY-DEVICE", build_id, "http://192.168.1.10:4000", None);
+//! match ota.check().await {
+//!     Ok(OtaCheckResult::UpdateAvailable(target)) => {
+//!         ota.download(&target.firmware_url, |offset, data| flash.write(offset, data)).await?;
+//!         mcuboot_mark_slot_ready(); // caller's responsibility
+//!         reboot();
+//!     }
+//!     Ok(OtaCheckResult::UpToDate) => {}
+//!     Err(e) => { /* handle */ }
+//! }
+//! ```
+
+use embedded_io_async::{Read, Write};
+use reqwless::client::HttpConnection;
+use reqwless::request::{Method, Request, RequestBuilder};
+use sha2::{Digest, Sha256};
+
+/// Result of a successful OTA check.
+pub enum OtaCheckResult {
+    /// Device firmware matches the server's target — no action needed.
+    UpToDate,
+    /// The server has a newer firmware target for this device.
+    UpdateAvailable(OtaTarget),
+}
+
+/// Firmware target returned by the server for this device.
+pub struct OtaTarget {
+    pub version: heapless::String<32>,
+    pub build_id: u64,
+    /// Relative URL path, e.g. `"/ota/firmware/3/download"`.
+    pub firmware_url: heapless::String<128>,
+}
+
+/// Errors produced by the OTA client.
+#[derive(Debug)]
+pub enum OtaError<E = core::convert::Infallible> {
+    /// An HTTP-level or transport error.
+    Http(reqwless::Error),
+    /// The server returned an unexpected non-200 / non-404 status.
+    ServerError(u16),
+    /// Response JSON could not be parsed to extract the required fields.
+    ParseError,
+    /// Downloaded firmware SHA-256 does not match the server's value.
+    HashMismatch,
+    /// Flash write callback returned an error.
+    FlashError(E),
+}
+
+/// OTA client using `reqwless` HTTP (WiFi / Ethernet devices).
+///
+/// Generic over the TCP connection type; the platform's network stack
+/// supplies a `T: embedded_io_async::Read + Write` handle.
+pub struct OtaClient<'a, T: Read + Write> {
+    connection: T,
+    device_id: &'a str,
+    current_build_id: u64,
+    base_url: &'a str,
+    api_key: Option<&'a str>,
+}
+
+impl<'a, T: Read + Write> OtaClient<'a, T> {
+    /// Create a new OTA client.
+    ///
+    /// - `connection`: Platform TCP socket (from esp-wifi / embassy-net).
+    /// - `device_id`: Exact device ID registered with the server.
+    /// - `current_build_id`: The `build_id` this firmware was compiled with.
+    /// - `base_url`: Server root, e.g. `"http://192.168.1.10:4000"`.
+    /// - `api_key`: Optional `X-API-Key` header value.
+    pub fn new(
+        connection: T,
+        device_id: &'a str,
+        current_build_id: u64,
+        base_url: &'a str,
+        api_key: Option<&'a str>,
+    ) -> Self {
+        Self {
+            connection,
+            device_id,
+            current_build_id,
+            base_url,
+            api_key,
+        }
+    }
+
+    /// Poll the server for a pending firmware target for this device.
+    ///
+    /// Returns `UpToDate` when no target is set (404) or when the target's
+    /// `build_id` matches `current_build_id`.
+    pub async fn check(&mut self) -> Result<OtaCheckResult, OtaError> {
+        let mut url: heapless::String<256> = heapless::String::new();
+        url.push_str(self.base_url)
+            .and_then(|_| url.push_str("/ota/targets/"))
+            .and_then(|_| url.push_str(self.device_id))
+            .map_err(|_| OtaError::ParseError)?;
+
+        let mut conn = HttpConnection::Plain(&mut self.connection);
+        let mut rx_buf = [0u8; 1024];
+
+        let resp = if let Some(key) = self.api_key {
+            let headers = [("X-API-Key", key)];
+            let req = Request::new(Method::GET, url.as_str())
+                .headers(&headers)
+                .build();
+            conn.send(req, &mut rx_buf).await.map_err(OtaError::Http)?
+        } else {
+            let req = Request::new(Method::GET, url.as_str()).build();
+            conn.send(req, &mut rx_buf).await.map_err(OtaError::Http)?
+        };
+
+        match resp.status.0 {
+            404 => return Ok(OtaCheckResult::UpToDate),
+            200 => {}
+            code => return Err(OtaError::ServerError(code)),
+        }
+
+        // Read body into a buffer for parsing
+        let mut body_buf = [0u8; 512];
+        let n = {
+            let mut body = resp.body().reader();
+            let mut total = 0usize;
+            while total < body_buf.len() {
+                match body.read(&mut body_buf[total..]).await {
+                    Ok(0) => break,
+                    Ok(n) => total += n,
+                    Err(_) => break,
+                }
+            }
+            total
+        };
+        let json = &body_buf[..n];
+
+        let target_build_id =
+            parse_u64_field(json, b"\"target_build_id\":").ok_or(OtaError::ParseError)?;
+
+        if target_build_id == self.current_build_id {
+            return Ok(OtaCheckResult::UpToDate);
+        }
+
+        let mut version: heapless::String<32> = heapless::String::new();
+        if let Some(v) = parse_str_field(json, b"\"target_version\":\"") {
+            for &b in v {
+                version.push(b as char).ok();
+            }
+        }
+
+        let mut firmware_url: heapless::String<128> = heapless::String::new();
+        let url_bytes =
+            parse_str_field(json, b"\"firmware_url\":\"").ok_or(OtaError::ParseError)?;
+        for &b in url_bytes {
+            firmware_url.push(b as char).ok();
+        }
+
+        Ok(OtaCheckResult::UpdateAvailable(OtaTarget {
+            version,
+            build_id: target_build_id,
+            firmware_url,
+        }))
+    }
+
+    /// Download firmware from the server and write it to flash in chunks.
+    ///
+    /// `firmware_url` is the relative path from `OtaTarget::firmware_url`
+    /// (e.g. `"/ota/firmware/3/download"`).
+    ///
+    /// `flash_write(offset, data)` is called for each chunk received. The
+    /// callback must write the data to the secondary MCUboot slot.
+    ///
+    /// SHA-256 is verified against the `X-Firmware-SHA256` response header
+    /// when present. Returns `HashMismatch` if verification fails.
+    pub async fn download<F, E>(
+        &mut self,
+        firmware_url: &str,
+        mut flash_write: F,
+    ) -> Result<(), OtaError<E>>
+    where
+        F: FnMut(u32, &[u8]) -> Result<(), E>,
+    {
+        let mut url: heapless::String<256> = heapless::String::new();
+        url.push_str(self.base_url)
+            .and_then(|_| url.push_str(firmware_url))
+            .map_err(|_| OtaError::ParseError)?;
+
+        let mut conn = HttpConnection::Plain(&mut self.connection);
+        let mut rx_buf = [0u8; 1024];
+
+        let resp = if let Some(key) = self.api_key {
+            let headers = [("X-API-Key", key)];
+            let req = Request::new(Method::GET, url.as_str())
+                .headers(&headers)
+                .build();
+            conn.send(req, &mut rx_buf).await.map_err(OtaError::Http)?
+        } else {
+            let req = Request::new(Method::GET, url.as_str()).build();
+            conn.send(req, &mut rx_buf).await.map_err(OtaError::Http)?
+        };
+
+        if resp.status.0 != 200 {
+            return Err(OtaError::ServerError(resp.status.0));
+        }
+
+        // Capture X-Firmware-SHA256 header value before body() consumes the response.
+        let mut sha256_buf = [0u8; 64];
+        let mut sha256_len = 0usize;
+        for (name, value) in resp.headers() {
+            if name.eq_ignore_ascii_case("x-firmware-sha256") {
+                sha256_len = value.len().min(64);
+                sha256_buf[..sha256_len].copy_from_slice(&value[..sha256_len]);
+                break;
+            }
+        }
+
+        let mut hasher = Sha256::new();
+        let mut chunk = [0u8; 512];
+        let mut offset = 0u32;
+        let mut body = resp.body().reader();
+
+        loop {
+            let n = body.read(&mut chunk).await.unwrap_or(0);
+            if n == 0 {
+                break;
+            }
+            hasher.update(&chunk[..n]);
+            flash_write(offset, &chunk[..n]).map_err(OtaError::FlashError)?;
+            offset += n as u32;
+        }
+
+        // Verify SHA-256 if the server sent the header.
+        if sha256_len == 64 {
+            let digest = hasher.finalize();
+            if !sha256_hex_matches(digest.as_ref(), &sha256_buf) {
+                return Err(OtaError::HashMismatch);
+            }
+        }
+
+        Ok(())
+    }
+}
+
+// ── JSON helpers ─────────────────────────────────────────────────────────────
+
+/// Find `"key":VALUE` in JSON bytes and parse VALUE as a u64.
+fn parse_u64_field(json: &[u8], key: &[u8]) -> Option<u64> {
+    let pos = json.windows(key.len()).position(|w| w == key)?;
+    let rest = &json[pos + key.len()..];
+    let start = rest.iter().position(|b| b.is_ascii_digit())?;
+    let digits = &rest[start..];
+    let end = digits
+        .iter()
+        .position(|b| !b.is_ascii_digit())
+        .unwrap_or(digits.len());
+    core::str::from_utf8(&digits[..end]).ok()?.parse().ok()
+}
+
+/// Find `"key":"VALUE"` in JSON bytes and return the VALUE slice.
+/// The `key` argument must include the trailing `:"` (opening quote).
+fn parse_str_field<'a>(json: &'a [u8], key: &[u8]) -> Option<&'a [u8]> {
+    let pos = json.windows(key.len()).position(|w| w == key)?;
+    let after = &json[pos + key.len()..];
+    let end = after.iter().position(|&b| b == b'"')?;
+    Some(&after[..end])
+}
+
+// ── SHA-256 comparison ────────────────────────────────────────────────────────
+
+const HEX_LOWER: [u8; 16] = *b"0123456789abcdef";
+
+/// Compare a raw SHA-256 digest against a lowercase hex string in a byte slice.
+fn sha256_hex_matches(digest: &[u8], hex: &[u8; 64]) -> bool {
+    if digest.len() != 32 {
+        return false;
+    }
+    for (i, &byte) in digest.iter().enumerate() {
+        if hex[i * 2] != HEX_LOWER[(byte >> 4) as usize]
+            || hex[i * 2 + 1] != HEX_LOWER[(byte & 0xF) as usize]
+        {
+            return false;
+        }
+    }
+    true
+}

--- a/ferrite-sdk/src/transport/http.rs
+++ b/ferrite-sdk/src/transport/http.rs
@@ -2,22 +2,23 @@
 //!
 //! Sends chunks directly to the ferrite-server's `/ingest/chunks` endpoint
 //! over an HTTP POST. Designed for WiFi-capable devices like ESP32-C3 or
-//! Raspberry Pi Pico W.
+//! STM32H563 (Ethernet).
 //!
 //! Requires the `http` feature flag.
 
 use embedded_io_async::{Read, Write};
-use reqwless::client::HttpClient;
-use reqwless::request::Method;
+use reqwless::client::HttpConnection;
+use reqwless::headers::ContentType;
+use reqwless::request::{Method, Request, RequestBuilder};
 
 /// HTTP transport that POSTs chunks directly to a ferrite-server.
 ///
-/// Generic over the TCP connection type — the platform WiFi stack provides
-/// the actual TCP implementation:
+/// Generic over the TCP connection type — the platform WiFi/Ethernet stack
+/// provides the actual TCP implementation:
 /// - ESP32-C3: `esp-wifi` + `embassy-net`
-/// - Pico W: `cyw43` + `embassy-net`
+/// - STM32H563: `embassy-net` Ethernet
 pub struct HttpTransport<'a, T: Read + Write> {
-    client: HttpClient<'a, T>,
+    connection: T,
     url: &'a str,
     api_key: Option<&'a str>,
 }
@@ -25,12 +26,12 @@ pub struct HttpTransport<'a, T: Read + Write> {
 impl<'a, T: Read + Write> HttpTransport<'a, T> {
     /// Create a new HTTP transport.
     ///
-    /// - `connection`: A TCP connection to the server (platform-specific).
+    /// - `connection`: A TCP socket from the platform's network stack.
     /// - `url`: Full URL to the ingest endpoint, e.g. `"http://192.168.1.100:4000/ingest/chunks"`.
     /// - `api_key`: Optional API key sent as `X-API-Key` header.
     pub fn new(connection: T, url: &'a str, api_key: Option<&'a str>) -> Self {
         Self {
-            client: HttpClient::new(connection),
+            connection,
             url,
             api_key,
         }
@@ -41,18 +42,30 @@ impl<'a, T: Read + Write> crate::transport::AsyncChunkTransport for HttpTranspor
     type Error = reqwless::Error;
 
     async fn send_chunk(&mut self, chunk: &[u8]) -> Result<(), Self::Error> {
-        let mut buf = [0u8; 512];
-        let mut req = self.client.request(Method::POST, self.url).await?;
-        req = req.content_type(reqwless::headers::ContentType::ApplicationOctetStream);
+        let mut conn = HttpConnection::Plain(&mut self.connection);
+        let mut rx_buf = [0u8; 512];
+
         if let Some(key) = self.api_key {
-            req = req.header("X-API-Key", key);
+            let headers = [("X-API-Key", key)];
+            let request = Request::new(Method::POST, self.url)
+                .content_type(ContentType::ApplicationOctetStream)
+                .headers(&headers)
+                .body(chunk)
+                .build();
+            conn.send(request, &mut rx_buf).await?;
+        } else {
+            let request = Request::new(Method::POST, self.url)
+                .content_type(ContentType::ApplicationOctetStream)
+                .body(chunk)
+                .build();
+            conn.send(request, &mut rx_buf).await?;
         }
-        let _resp = req.body(chunk).send(&mut buf).await?;
+
         Ok(())
     }
 
     fn is_available(&self) -> bool {
-        true // Assume WiFi is connected if we have a TCP handle
+        true
     }
 
     async fn begin_session(&mut self) -> Result<(), Self::Error> {


### PR DESCRIPTION
## Summary
- Adds `ferrite_sdk::ota::OtaClient` gated behind the `http` feature
- `check()` polls `GET /ota/targets/:device_id` — returns `UpToDate` or `UpdateAvailable(OtaTarget)`
- `download()` streams firmware to flash via a `FnMut(offset, data)` callback, verifies SHA-256 against `X-Firmware-SHA256` response header
- Also fixes `transport/http.rs` to use the correct reqwless 0.12 `HttpConnection` API (previous code used a 0.11-era `HttpClient` constructor that no longer exists)

## Test plan
- [ ] `cargo build -p ferrite-sdk --features http --no-default-features -j4` passes clean
- [ ] `cargo test -p ferrite-sdk --no-default-features -j4` — all 45 tests pass
- [ ] On ESP32-C3 or STM32H563 (HTTP-capable boards): call `OtaClient::check()` after `UploadManager::upload_async()`, flash a firmware, verify SHA-256 match and MCUboot slot swap

🤖 Generated with [Claude Code](https://claude.com/claude-code)