### PR TITLE
feat: Sprint 2d — OTA campaign dashboard pages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,14 +4,14 @@
 
 # ── Stage 1: Build ───────────────────────────────────────────────────
 
-FROM rust:1.84-bookworm AS builder
+FROM rust:latest AS builder
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     pkg-config libssl-dev \
     && rm -rf /var/lib/apt/lists/*
 
 RUN rustup target add wasm32-unknown-unknown
-RUN cargo install dioxus-cli@0.6.3 --locked
+RUN cargo install dioxus-cli@0.7.6
 
 WORKDIR /app
 COPY . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 
 # ── Stage 1: Build ───────────────────────────────────────────────────
 
-FROM rust:latest AS builder
+FROM rust:1.95-bookworm AS builder
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     pkg-config libssl-dev \

--- a/ferrite-dashboard/src/api/client.rs
+++ b/ferrite-dashboard/src/api/client.rs
@@ -371,6 +371,174 @@ impl ApiClient {
         }
     }
 
+    // ── OTA Campaigns ────────────────────────────────────────────────────────
+
+    pub async fn list_campaigns(&self) -> Result<Vec<OtaCampaign>, ApiError> {
+        let url = format!("{}/ota/campaigns", self.base_url);
+        let resp = self
+            .build_get(&url)
+            .send()
+            .await
+            .map_err(|e| ApiError::Network(e.to_string()))?;
+        match resp.status().as_u16() {
+            200 => {
+                #[derive(Deserialize)]
+                struct W {
+                    campaigns: Vec<OtaCampaign>,
+                }
+                let w: W = resp.json().await.map_err(|e| ApiError::Parse(e.to_string()))?;
+                Ok(w.campaigns)
+            }
+            401 => Err(ApiError::Unauthorized),
+            code => Err(ApiError::Server(format!("HTTP {code}"))),
+        }
+    }
+
+    pub async fn get_campaign(&self, id: i64) -> Result<CampaignSummary, ApiError> {
+        let url = format!("{}/ota/campaigns/{}", self.base_url, id);
+        let resp = self
+            .build_get(&url)
+            .send()
+            .await
+            .map_err(|e| ApiError::Network(e.to_string()))?;
+        match resp.status().as_u16() {
+            200 => {
+                #[derive(Deserialize)]
+                struct W {
+                    campaign: CampaignSummary,
+                }
+                let w: W = resp.json().await.map_err(|e| ApiError::Parse(e.to_string()))?;
+                Ok(w.campaign)
+            }
+            401 => Err(ApiError::Unauthorized),
+            404 => Err(ApiError::NotFound),
+            code => Err(ApiError::Server(format!("HTTP {code}"))),
+        }
+    }
+
+    pub async fn list_campaign_devices(&self, id: i64) -> Result<Vec<CampaignDevice>, ApiError> {
+        let url = format!("{}/ota/campaigns/{}/devices", self.base_url, id);
+        let resp = self
+            .build_get(&url)
+            .send()
+            .await
+            .map_err(|e| ApiError::Network(e.to_string()))?;
+        match resp.status().as_u16() {
+            200 => {
+                #[derive(Deserialize)]
+                struct W {
+                    devices: Vec<CampaignDevice>,
+                }
+                let w: W = resp.json().await.map_err(|e| ApiError::Parse(e.to_string()))?;
+                Ok(w.devices)
+            }
+            401 => Err(ApiError::Unauthorized),
+            code => Err(ApiError::Server(format!("HTTP {code}"))),
+        }
+    }
+
+    pub async fn create_campaign(
+        &self,
+        name: &str,
+        firmware_id: i64,
+        target_version: &str,
+        strategy: &str,
+        rollout_percent: i64,
+    ) -> Result<OtaCampaign, ApiError> {
+        let url = format!("{}/ota/campaigns", self.base_url);
+        let body = serde_json::json!({
+            "name": name,
+            "firmware_id": firmware_id,
+            "target_version": target_version,
+            "strategy": strategy,
+            "rollout_percent": rollout_percent,
+        });
+        let resp = self
+            .build_post(&url)
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| ApiError::Network(e.to_string()))?;
+        match resp.status().as_u16() {
+            201 | 200 => {
+                #[derive(Deserialize)]
+                struct W {
+                    campaign: OtaCampaign,
+                }
+                let w: W = resp.json().await.map_err(|e| ApiError::Parse(e.to_string()))?;
+                Ok(w.campaign)
+            }
+            400 => Err(ApiError::Parse("invalid campaign request".into())),
+            401 => Err(ApiError::Unauthorized),
+            code => Err(ApiError::Server(format!("HTTP {code}"))),
+        }
+    }
+
+    pub async fn activate_campaign(&self, id: i64) -> Result<(), ApiError> {
+        let url = format!("{}/ota/campaigns/{}/activate", self.base_url, id);
+        let resp = self
+            .build_post(&url)
+            .send()
+            .await
+            .map_err(|e| ApiError::Network(e.to_string()))?;
+        match resp.status().as_u16() {
+            200 => Ok(()),
+            401 => Err(ApiError::Unauthorized),
+            code => Err(ApiError::Server(format!("HTTP {code}"))),
+        }
+    }
+
+    pub async fn pause_campaign(&self, id: i64) -> Result<(), ApiError> {
+        let url = format!("{}/ota/campaigns/{}/pause", self.base_url, id);
+        let resp = self
+            .build_post(&url)
+            .send()
+            .await
+            .map_err(|e| ApiError::Network(e.to_string()))?;
+        match resp.status().as_u16() {
+            200 => Ok(()),
+            401 => Err(ApiError::Unauthorized),
+            code => Err(ApiError::Server(format!("HTTP {code}"))),
+        }
+    }
+
+    pub async fn rollback_campaign(&self, id: i64) -> Result<(), ApiError> {
+        let url = format!("{}/ota/campaigns/{}/rollback", self.base_url, id);
+        let resp = self
+            .build_post(&url)
+            .send()
+            .await
+            .map_err(|e| ApiError::Network(e.to_string()))?;
+        match resp.status().as_u16() {
+            200 => Ok(()),
+            401 => Err(ApiError::Unauthorized),
+            code => Err(ApiError::Server(format!("HTTP {code}"))),
+        }
+    }
+
+    // ── Firmware Artifacts ───────────────────────────────────────────────────
+
+    pub async fn list_firmware(&self) -> Result<Vec<FirmwareArtifact>, ApiError> {
+        let url = format!("{}/ota/firmware", self.base_url);
+        let resp = self
+            .build_get(&url)
+            .send()
+            .await
+            .map_err(|e| ApiError::Network(e.to_string()))?;
+        match resp.status().as_u16() {
+            200 => {
+                #[derive(Deserialize)]
+                struct W {
+                    artifacts: Vec<FirmwareArtifact>,
+                }
+                let w: W = resp.json().await.map_err(|e| ApiError::Parse(e.to_string()))?;
+                Ok(w.artifacts)
+            }
+            401 => Err(ApiError::Unauthorized),
+            code => Err(ApiError::Server(format!("HTTP {code}"))),
+        }
+    }
+
     pub async fn delete_device(&self, device_key: &str) -> Result<(), ApiError> {
         let url = format!("{}/devices/{}", self.base_url, device_key);
         let resp = self

--- a/ferrite-dashboard/src/api/client.rs
+++ b/ferrite-dashboard/src/api/client.rs
@@ -386,7 +386,10 @@ impl ApiClient {
                 struct W {
                     campaigns: Vec<OtaCampaign>,
                 }
-                let w: W = resp.json().await.map_err(|e| ApiError::Parse(e.to_string()))?;
+                let w: W = resp
+                    .json()
+                    .await
+                    .map_err(|e| ApiError::Parse(e.to_string()))?;
                 Ok(w.campaigns)
             }
             401 => Err(ApiError::Unauthorized),
@@ -407,7 +410,10 @@ impl ApiClient {
                 struct W {
                     campaign: CampaignSummary,
                 }
-                let w: W = resp.json().await.map_err(|e| ApiError::Parse(e.to_string()))?;
+                let w: W = resp
+                    .json()
+                    .await
+                    .map_err(|e| ApiError::Parse(e.to_string()))?;
                 Ok(w.campaign)
             }
             401 => Err(ApiError::Unauthorized),
@@ -429,7 +435,10 @@ impl ApiClient {
                 struct W {
                     devices: Vec<CampaignDevice>,
                 }
-                let w: W = resp.json().await.map_err(|e| ApiError::Parse(e.to_string()))?;
+                let w: W = resp
+                    .json()
+                    .await
+                    .map_err(|e| ApiError::Parse(e.to_string()))?;
                 Ok(w.devices)
             }
             401 => Err(ApiError::Unauthorized),
@@ -465,7 +474,10 @@ impl ApiClient {
                 struct W {
                     campaign: OtaCampaign,
                 }
-                let w: W = resp.json().await.map_err(|e| ApiError::Parse(e.to_string()))?;
+                let w: W = resp
+                    .json()
+                    .await
+                    .map_err(|e| ApiError::Parse(e.to_string()))?;
                 Ok(w.campaign)
             }
             400 => Err(ApiError::Parse("invalid campaign request".into())),
@@ -531,7 +543,10 @@ impl ApiClient {
                 struct W {
                     artifacts: Vec<FirmwareArtifact>,
                 }
-                let w: W = resp.json().await.map_err(|e| ApiError::Parse(e.to_string()))?;
+                let w: W = resp
+                    .json()
+                    .await
+                    .map_err(|e| ApiError::Parse(e.to_string()))?;
                 Ok(w.artifacts)
             }
             401 => Err(ApiError::Unauthorized),

--- a/ferrite-dashboard/src/api/types.rs
+++ b/ferrite-dashboard/src/api/types.rs
@@ -130,6 +130,120 @@ impl CrashGroup {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct OtaCampaign {
+    pub id: i64,
+    pub name: String,
+    pub firmware_id: i64,
+    pub target_version: String,
+    pub strategy: String,
+    pub target_group_id: Option<i64>,
+    pub target_tags: Option<String>,
+    pub rollout_percent: i64,
+    pub failure_threshold: f64,
+    pub status: String,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+impl OtaCampaign {
+    pub fn status_color(&self) -> &'static str {
+        match self.status.as_str() {
+            "active" => "text-green-400 bg-green-400/10 border-green-500/20",
+            "paused" => "text-yellow-400 bg-yellow-400/10 border-yellow-500/20",
+            "completed" => "text-blue-400 bg-blue-400/10 border-blue-500/20",
+            "rolled_back" => "text-orange-400 bg-orange-400/10 border-orange-500/20",
+            "failed" => "text-red-400 bg-red-400/10 border-red-500/20",
+            _ => "text-gray-400 bg-gray-400/10 border-gray-500/20",
+        }
+    }
+
+    pub fn strategy_color(&self) -> &'static str {
+        match self.strategy.as_str() {
+            "canary" => "text-amber-400 bg-amber-400/10 border-amber-500/20",
+            "scheduled" => "text-blue-400 bg-blue-400/10 border-blue-500/20",
+            _ => "text-gray-400 bg-gray-400/10 border-gray-500/20",
+        }
+    }
+
+    pub fn can_activate(&self) -> bool {
+        matches!(self.status.as_str(), "created" | "paused")
+    }
+
+    pub fn can_pause(&self) -> bool {
+        self.status == "active"
+    }
+
+    pub fn can_rollback(&self) -> bool {
+        matches!(self.status.as_str(), "active" | "paused")
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct CampaignSummary {
+    pub campaign: OtaCampaign,
+    pub pending: i64,
+    pub downloading: i64,
+    pub installed: i64,
+    pub failed: i64,
+}
+
+impl CampaignSummary {
+    pub fn total_devices(&self) -> i64 {
+        self.pending + self.downloading + self.installed + self.failed
+    }
+
+    pub fn progress_pct(&self) -> u32 {
+        let total = self.total_devices();
+        if total == 0 {
+            return 0;
+        }
+        ((self.installed * 100) / total) as u32
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct CampaignDevice {
+    pub id: i64,
+    pub campaign_id: i64,
+    pub device_id: String,
+    pub status: String,
+    pub updated_at: String,
+}
+
+impl CampaignDevice {
+    pub fn status_color(&self) -> &'static str {
+        match self.status.as_str() {
+            "installed" => "text-green-400 bg-green-400/10 border-green-500/20",
+            "downloading" => "text-blue-400 bg-blue-400/10 border-blue-500/20",
+            "failed" => "text-red-400 bg-red-400/10 border-red-500/20",
+            _ => "text-gray-400 bg-gray-400/10 border-gray-500/20",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct FirmwareArtifact {
+    pub id: i64,
+    pub version: String,
+    pub build_id: i64,
+    pub sha256: String,
+    pub size: i64,
+    pub filename: String,
+    pub signer: Option<String>,
+    pub created_at: String,
+}
+
+impl FirmwareArtifact {
+    pub fn size_display(&self) -> String {
+        if self.size >= 1024 * 1024 {
+            format!("{:.1} MB", self.size as f64 / (1024.0 * 1024.0))
+        } else {
+            format!("{} KB", self.size / 1024)
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct TraceEntry {
     pub id: String,
     pub device_id: String,

--- a/ferrite-dashboard/src/components/navbar.rs
+++ b/ferrite-dashboard/src/components/navbar.rs
@@ -138,6 +138,12 @@ pub fn Navbar() -> Element {
                         on_click: move |_| mobile_open.set(false),
                     }
                     SidebarLink {
+                        to: Route::Ota {},
+                        label: "OTA",
+                        icon_path: "M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M9 19l3 3m0 0l3-3m-3 3V10",
+                        on_click: move |_| mobile_open.set(false),
+                    }
+                    SidebarLink {
                         to: Route::Compare {},
                         label: "Compare",
                         icon_path: "M9 17V7m0 10a2 2 0 01-2 2H5a2 2 0 01-2-2V7a2 2 0 012-2h2a2 2 0 012 2m0 10a2 2 0 002 2h2a2 2 0 002-2M9 7a2 2 0 012-2h2a2 2 0 012 2m0 10V7m0 10a2 2 0 002 2h2a2 2 0 002-2V7a2 2 0 00-2-2h-2a2 2 0 00-2 2",

--- a/ferrite-dashboard/src/main.rs
+++ b/ferrite-dashboard/src/main.rs
@@ -35,6 +35,12 @@ pub enum Route {
         Fleet {},
         #[route("/compare")]
         Compare {},
+        #[route("/ota")]
+        Ota {},
+        #[route("/ota/campaigns/new")]
+        CampaignNew {},
+        #[route("/ota/campaigns/:id")]
+        CampaignDetail { id: String },
         #[route("/settings")]
         Settings {},
     #[end_layout]
@@ -146,6 +152,24 @@ fn Fleet() -> Element {
 #[component]
 fn Compare() -> Element {
     rsx! { ComparePage {} }
+}
+
+/// OTA campaigns list route handler.
+#[component]
+fn Ota() -> Element {
+    rsx! { OtaPage {} }
+}
+
+/// New campaign wizard route handler.
+#[component]
+fn CampaignNew() -> Element {
+    rsx! { CampaignNewPage {} }
+}
+
+/// Campaign detail route handler.
+#[component]
+fn CampaignDetail(id: String) -> Element {
+    rsx! { CampaignDetailPage { id } }
 }
 
 /// Settings page route handler.

--- a/ferrite-dashboard/src/pages/campaign_detail.rs
+++ b/ferrite-dashboard/src/pages/campaign_detail.rs
@@ -1,0 +1,236 @@
+use crate::api::types::*;
+use crate::auth::AuthState;
+use crate::components::{ErrorDisplay, Loading};
+use crate::Route;
+use dioxus::prelude::*;
+
+#[component]
+pub fn CampaignDetailPage(id: String) -> Element {
+    let auth_state = use_context::<Signal<AuthState>>();
+    let poll_tick = crate::hooks::use_poll_tick();
+    let mut reload = use_signal(|| 0u32);
+
+    let id_clone = id.clone();
+    let campaign_id: i64 = id.parse().unwrap_or(0);
+
+    let summary_resource = use_resource(move || {
+        let id_str = id_clone.clone();
+        async move {
+            let _tick = poll_tick();
+            let _r = reload();
+            let cid: i64 = id_str.parse().unwrap_or(0);
+            let client = crate::api::client::authenticated_client(&auth_state());
+            client.get_campaign(cid).await
+        }
+    });
+
+    let devices_resource = use_resource(move || async move {
+        let _tick = poll_tick();
+        let _r = reload();
+        let client = crate::api::client::authenticated_client(&auth_state());
+        client.list_campaign_devices(campaign_id).await
+    });
+
+    let summary_binding = summary_resource.read();
+    let summary = match &*summary_binding {
+        None => return rsx! { Loading {} },
+        Some(Err(e)) => return rsx! { ErrorDisplay { message: e.to_string() } },
+        Some(Ok(s)) => s.clone(),
+    };
+
+    let devices: Vec<CampaignDevice> = match &*devices_resource.read() {
+        Some(Ok(d)) => d.clone(),
+        _ => vec![],
+    };
+
+    let camp = &summary.campaign;
+    let total = summary.total_devices();
+    let pct = summary.progress_pct();
+
+    rsx! {
+        div {
+            class: "p-6 lg:p-8 max-w-[1400px] mx-auto",
+
+            // Breadcrumb
+            div {
+                class: "flex items-center gap-2 text-sm text-gray-500 mb-5",
+                Link { to: Route::Ota {}, class: "hover:text-gray-300 transition-colors", "OTA" }
+                span { "/" }
+                span { class: "text-gray-300", "{camp.name}" }
+            }
+
+            // Campaign header
+            div {
+                class: "bg-surface-900 rounded-xl border border-surface-700 p-5 mb-6 animate-fade-in",
+                div {
+                    class: "flex flex-col sm:flex-row sm:items-start justify-between gap-4",
+                    div {
+                        div { class: "flex items-center gap-3 mb-3",
+                            h1 { class: "text-xl font-semibold text-gray-100", "{camp.name}" }
+                            span {
+                                class: "inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium border {camp.status_color()}",
+                                "{camp.status}"
+                            }
+                            span {
+                                class: "inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium border {camp.strategy_color()}",
+                                "{camp.strategy}"
+                            }
+                        }
+                        div { class: "flex flex-wrap gap-4 text-sm",
+                            InfoChip { label: "Target version", value: camp.target_version.clone() }
+                            InfoChip { label: "Rollout", value: format!("{}%", camp.rollout_percent) }
+                            InfoChip { label: "Created", value: camp.created_at[..10].to_string() }
+                        }
+                    }
+                    // Action buttons
+                    div { class: "flex items-center gap-2 flex-shrink-0",
+                        if camp.can_activate() {
+                            button {
+                                class: "px-3 py-1.5 text-sm font-medium bg-green-500/10 border border-green-500/20 text-green-400 rounded-lg hover:bg-green-500/20 transition-colors",
+                                onclick: move |_| {
+                                    let client = crate::api::client::authenticated_client(&auth_state());
+                                    spawn(async move {
+                                        let _ = client.activate_campaign(campaign_id).await;
+                                        reload.set(reload() + 1);
+                                    });
+                                },
+                                "Activate"
+                            }
+                        }
+                        if camp.can_pause() {
+                            button {
+                                class: "px-3 py-1.5 text-sm font-medium bg-yellow-500/10 border border-yellow-500/20 text-yellow-400 rounded-lg hover:bg-yellow-500/20 transition-colors",
+                                onclick: move |_| {
+                                    let client = crate::api::client::authenticated_client(&auth_state());
+                                    spawn(async move {
+                                        let _ = client.pause_campaign(campaign_id).await;
+                                        reload.set(reload() + 1);
+                                    });
+                                },
+                                "Pause"
+                            }
+                        }
+                        if camp.can_rollback() {
+                            button {
+                                class: "px-3 py-1.5 text-sm font-medium bg-red-500/10 border border-red-500/20 text-red-400 rounded-lg hover:bg-red-500/20 transition-colors",
+                                onclick: move |_| {
+                                    let client = crate::api::client::authenticated_client(&auth_state());
+                                    spawn(async move {
+                                        let _ = client.rollback_campaign(campaign_id).await;
+                                        reload.set(reload() + 1);
+                                    });
+                                },
+                                "Rollback"
+                            }
+                        }
+                    }
+                }
+            }
+
+            // Progress summary
+            div {
+                class: "grid grid-cols-2 sm:grid-cols-4 gap-4 mb-6",
+                ProgressCard { label: "Pending", value: summary.pending, color: "gray" }
+                ProgressCard { label: "Downloading", value: summary.downloading, color: "blue" }
+                ProgressCard { label: "Installed", value: summary.installed, color: "green" }
+                ProgressCard { label: "Failed", value: summary.failed, color: "red" }
+            }
+
+            // Progress bar
+            if total > 0 {
+                div {
+                    class: "bg-surface-900 rounded-xl border border-surface-700 p-4 mb-6",
+                    div { class: "flex items-center justify-between mb-2",
+                        p { class: "text-xs text-gray-400 font-medium", "Installation progress" }
+                        p { class: "text-xs font-mono text-ferrite-400 font-semibold", "{pct}% ({summary.installed}/{total})" }
+                    }
+                    div { class: "w-full bg-surface-700 rounded-full h-2",
+                        div {
+                            class: "bg-ferrite-500 h-2 rounded-full transition-all duration-500",
+                            style: "width: {pct}%",
+                        }
+                    }
+                }
+            }
+
+            // Device table
+            div {
+                class: "bg-surface-900 rounded-xl border border-surface-700",
+                div {
+                    class: "px-5 py-4 border-b border-surface-700 flex items-center justify-between",
+                    h2 { class: "text-sm font-semibold text-gray-200", "Device Progress" }
+                    p {
+                        class: "text-[10px] font-mono text-gray-600 uppercase tracking-wider",
+                        "{devices.len()} device(s)"
+                    }
+                }
+                if devices.is_empty() {
+                    div { class: "p-8 text-center",
+                        p { class: "text-sm text-gray-500", "No devices enrolled in this campaign" }
+                    }
+                } else {
+                    div { class: "overflow-x-auto",
+                        table { class: "w-full text-sm",
+                            thead {
+                                tr { class: "border-b border-surface-700",
+                                    th { class: "px-5 py-3 text-left text-[10px] font-semibold text-gray-500 uppercase tracking-wider", "Device ID" }
+                                    th { class: "px-5 py-3 text-left text-[10px] font-semibold text-gray-500 uppercase tracking-wider", "Status" }
+                                    th { class: "px-5 py-3 text-left text-[10px] font-semibold text-gray-500 uppercase tracking-wider", "Last Updated" }
+                                }
+                            }
+                            tbody {
+                                for device in devices.iter() {
+                                    tr { class: "border-b border-surface-800 hover:bg-surface-800/50 transition-colors",
+                                        td { class: "px-5 py-3 font-mono text-gray-200 text-xs",
+                                            Link {
+                                                to: Route::DeviceDetail { id: device.device_id.clone() },
+                                                class: "hover:text-ferrite-400 transition-colors",
+                                                "{device.device_id}"
+                                            }
+                                        }
+                                        td { class: "px-5 py-3",
+                                            span {
+                                                class: "inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium border {device.status_color()}",
+                                                "{device.status}"
+                                            }
+                                        }
+                                        td { class: "px-5 py-3 text-gray-500 text-xs font-mono",
+                                            "{device.updated_at.get(..16).unwrap_or(&device.updated_at)}"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[component]
+fn InfoChip(label: String, value: String) -> Element {
+    rsx! {
+        div {
+            span { class: "text-gray-500 text-xs", "{label}: " }
+            span { class: "text-gray-300 text-xs font-mono", "{value}" }
+        }
+    }
+}
+
+#[component]
+fn ProgressCard(label: String, value: i64, color: String) -> Element {
+    let accent = match color.as_str() {
+        "green" => "text-green-400",
+        "blue" => "text-blue-400",
+        "red" => "text-red-400",
+        _ => "text-gray-400",
+    };
+    rsx! {
+        div {
+            class: "bg-surface-900 rounded-xl border border-surface-700 p-4",
+            p { class: "text-[10px] font-semibold text-gray-500 uppercase tracking-wider mb-1", "{label}" }
+            p { class: "text-2xl font-bold font-mono {accent}", "{value}" }
+        }
+    }
+}

--- a/ferrite-dashboard/src/pages/campaign_new.rs
+++ b/ferrite-dashboard/src/pages/campaign_new.rs
@@ -1,0 +1,308 @@
+use crate::api::types::*;
+use crate::auth::AuthState;
+use crate::components::{ErrorDisplay, Loading};
+use crate::Route;
+use dioxus::prelude::*;
+
+#[component]
+pub fn CampaignNewPage() -> Element {
+    let auth_state = use_context::<Signal<AuthState>>();
+    let nav = use_navigator();
+
+    // Wizard step: 0 = pick firmware, 1 = configure
+    let mut step = use_signal(|| 0u8);
+    let mut selected_firmware: Signal<Option<FirmwareArtifact>> = use_signal(|| None);
+    let mut name = use_signal(|| String::new());
+    let mut strategy = use_signal(|| "immediate".to_string());
+    let mut rollout_pct = use_signal(|| 100i64);
+    let mut activate_now = use_signal(|| true);
+    let mut submitting = use_signal(|| false);
+    let mut error_msg: Signal<Option<String>> = use_signal(|| None);
+
+    let firmware_resource = use_resource(move || async move {
+        let client = crate::api::client::authenticated_client(&auth_state());
+        client.list_firmware().await
+    });
+
+    let firmware_binding = firmware_resource.read();
+
+    rsx! {
+        div {
+            class: "p-6 lg:p-8 max-w-2xl mx-auto",
+
+            // Header
+            div { class: "mb-6 animate-fade-in",
+                div { class: "flex items-center gap-2 text-sm text-gray-500 mb-3",
+                    Link { to: Route::Ota {}, class: "hover:text-gray-300 transition-colors", "OTA" }
+                    span { "/" }
+                    span { class: "text-gray-300", "New Campaign" }
+                }
+                h1 { class: "text-2xl font-semibold text-gray-100", "New OTA Campaign" }
+                p { class: "mt-1 text-sm text-gray-500", "Deploy a firmware update to your fleet" }
+            }
+
+            // Step indicator
+            div { class: "flex items-center gap-3 mb-6",
+                StepDot { n: 1, active: step() == 0, done: step() > 0, label: "Select Firmware" }
+                div { class: "flex-1 h-px bg-surface-700" }
+                StepDot { n: 2, active: step() == 1, done: false, label: "Configure" }
+            }
+
+            if let Some(msg) = error_msg() {
+                div {
+                    class: "mb-4 px-4 py-3 bg-red-500/10 border border-red-500/20 rounded-lg text-sm text-red-400",
+                    "{msg}"
+                }
+            }
+
+            // ── Step 0: Firmware picker ──────────────────────────────────────
+            if step() == 0 {
+                div {
+                    match &*firmware_binding {
+                        None => rsx! { Loading {} },
+                        Some(Err(e)) => rsx! { ErrorDisplay { message: e.to_string() } },
+                        Some(Ok(artifacts)) => {
+                            if artifacts.is_empty() {
+                                rsx! {
+                                    div {
+                                        class: "bg-surface-900 rounded-xl border border-surface-700 p-10 text-center",
+                                        p { class: "text-sm text-gray-500 mb-2", "No firmware artifacts uploaded yet" }
+                                        p { class: "text-xs text-gray-600 font-mono",
+                                            "ferrite firmware upload --file firmware.bin --version 1.0.0"
+                                        }
+                                    }
+                                }
+                            } else {
+                                rsx! {
+                                    div {
+                                        class: "space-y-2 mb-6",
+                                        for artifact in artifacts.iter() {
+                                            FirmwareCard {
+                                                artifact: artifact.clone(),
+                                                selected: selected_firmware().as_ref().map(|f| f.id) == Some(artifact.id),
+                                                on_select: move |a: FirmwareArtifact| {
+                                                    selected_firmware.set(Some(a));
+                                                },
+                                            }
+                                        }
+                                    }
+                                    div { class: "flex justify-end",
+                                        button {
+                                            class: "px-5 py-2 bg-ferrite-600 text-white rounded-lg hover:bg-ferrite-500 text-sm font-medium transition-colors disabled:opacity-40",
+                                            disabled: selected_firmware().is_none(),
+                                            onclick: move |_| {
+                                                if selected_firmware().is_some() {
+                                                    step.set(1);
+                                                }
+                                            },
+                                            "Next: Configure →"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            // ── Step 1: Configuration ────────────────────────────────────────
+            if step() == 1 {
+                div {
+                    class: "bg-surface-900 rounded-xl border border-surface-700 p-5 mb-4",
+
+                    // Selected firmware summary
+                    if let Some(f) = selected_firmware() {
+                        div {
+                            class: "mb-5 p-3 bg-ferrite-600/10 border border-ferrite-600/20 rounded-lg",
+                            p { class: "text-xs text-gray-400 mb-0.5", "Selected firmware" }
+                            p { class: "text-sm font-mono text-ferrite-400 font-semibold",
+                                "{f.version} — {f.size_display()} — #{f.build_id}"
+                            }
+                        }
+                    }
+
+                    div { class: "space-y-4",
+                        // Campaign name
+                        div {
+                            label {
+                                class: "block text-xs font-semibold text-gray-400 uppercase tracking-wider mb-1.5",
+                                "Campaign Name"
+                            }
+                            input {
+                                class: "w-full px-3 py-2.5 bg-surface-800 border border-surface-600 rounded-lg text-sm text-gray-200 placeholder-gray-600 focus:ring-2 focus:ring-ferrite-500/40 focus:border-ferrite-600 outline-none transition-all font-mono",
+                                placeholder: "e.g. rollout-v2.1-prod",
+                                value: "{name}",
+                                oninput: move |e| name.set(e.value()),
+                            }
+                        }
+
+                        // Strategy
+                        div {
+                            label {
+                                class: "block text-xs font-semibold text-gray-400 uppercase tracking-wider mb-1.5",
+                                "Rollout Strategy"
+                            }
+                            select {
+                                class: "w-full px-3 py-2.5 bg-surface-800 border border-surface-600 rounded-lg text-sm text-gray-300 focus:ring-2 focus:ring-ferrite-500/40 focus:border-ferrite-600 outline-none transition-all",
+                                value: "{strategy}",
+                                onchange: move |e| strategy.set(e.value()),
+                                option { value: "immediate", "Immediate — push to all devices at once" }
+                                option { value: "canary", "Canary — push to a percentage first" }
+                                option { value: "scheduled", "Scheduled — push on activation" }
+                            }
+                        }
+
+                        // Rollout percent (canary only)
+                        if strategy() == "canary" {
+                            div {
+                                label {
+                                    class: "block text-xs font-semibold text-gray-400 uppercase tracking-wider mb-1.5",
+                                    "Canary Rollout Percent: {rollout_pct}%"
+                                }
+                                input {
+                                    class: "w-full accent-ferrite-500",
+                                    r#type: "range",
+                                    min: "1",
+                                    max: "100",
+                                    value: "{rollout_pct}",
+                                    oninput: move |e| {
+                                        if let Ok(v) = e.value().parse::<i64>() {
+                                            rollout_pct.set(v);
+                                        }
+                                    },
+                                }
+                                div { class: "flex justify-between text-xs text-gray-600 mt-1",
+                                    span { "1%" }
+                                    span { "50%" }
+                                    span { "100%" }
+                                }
+                            }
+                        }
+
+                        // Activate immediately
+                        div { class: "flex items-center gap-3",
+                            input {
+                                r#type: "checkbox",
+                                class: "accent-ferrite-500 h-4 w-4",
+                                id: "activate-now",
+                                checked: activate_now(),
+                                onchange: move |e| activate_now.set(e.checked()),
+                            }
+                            label {
+                                r#for: "activate-now",
+                                class: "text-sm text-gray-300 cursor-pointer",
+                                "Activate campaign immediately after creation"
+                            }
+                        }
+                    }
+                }
+
+                div { class: "flex items-center justify-between",
+                    button {
+                        class: "px-4 py-2 text-sm text-gray-400 hover:text-gray-200 transition-colors",
+                        onclick: move |_| step.set(0),
+                        "← Back"
+                    }
+                    button {
+                        class: "px-5 py-2 bg-ferrite-600 text-white rounded-lg hover:bg-ferrite-500 text-sm font-medium transition-colors disabled:opacity-40",
+                        disabled: name().trim().is_empty() || submitting(),
+                        onclick: move |_| {
+                            let Some(firmware) = selected_firmware() else { return; };
+                            let campaign_name = name().trim().to_string();
+                            if campaign_name.is_empty() { return; }
+
+                            submitting.set(true);
+                            error_msg.set(None);
+
+                            let strat = strategy();
+                            let pct = rollout_pct();
+                            let do_activate = activate_now();
+                            let nav = nav.clone();
+
+                            let client = crate::api::client::authenticated_client(&auth_state());
+                            spawn(async move {
+                                match client.create_campaign(
+                                    &campaign_name,
+                                    firmware.id,
+                                    &firmware.version,
+                                    &strat,
+                                    pct,
+                                ).await {
+                                    Ok(campaign) => {
+                                        let cid = campaign.id;
+                                        if do_activate {
+                                            let _ = client.activate_campaign(cid).await;
+                                        }
+                                        nav.push(Route::CampaignDetail { id: cid.to_string() });
+                                    }
+                                    Err(e) => {
+                                        error_msg.set(Some(e.to_string()));
+                                        submitting.set(false);
+                                    }
+                                }
+                            });
+                        },
+                        if submitting() { "Creating…" } else { "Create Campaign" }
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[component]
+fn FirmwareCard(
+    artifact: FirmwareArtifact,
+    selected: bool,
+    on_select: EventHandler<FirmwareArtifact>,
+) -> Element {
+    let border = if selected {
+        "border-ferrite-500 bg-ferrite-600/10"
+    } else {
+        "border-surface-600 hover:border-surface-500 bg-surface-900"
+    };
+
+    rsx! {
+        button {
+            class: "w-full text-left p-4 rounded-xl border {border} transition-all",
+            onclick: move |_| on_select.call(artifact.clone()),
+            div { class: "flex items-center justify-between",
+                div {
+                    p { class: "text-sm font-mono font-semibold text-ferrite-400", "{artifact.version}" }
+                    p { class: "text-xs text-gray-500 mt-0.5",
+                        "Build #{artifact.build_id} · {artifact.size_display()} · {artifact.created_at.get(..10).unwrap_or(&artifact.created_at)}"
+                    }
+                }
+                if selected {
+                    div { class: "h-5 w-5 rounded-full bg-ferrite-500 flex items-center justify-center flex-shrink-0",
+                        svg { class: "h-3 w-3 text-white", fill: "none", view_box: "0 0 24 24", stroke: "currentColor", stroke_width: "3",
+                            path { stroke_linecap: "round", stroke_linejoin: "round", d: "M5 13l4 4L19 7" }
+                        }
+                    }
+                } else {
+                    div { class: "h-5 w-5 rounded-full border border-surface-500 flex-shrink-0" }
+                }
+            }
+        }
+    }
+}
+
+#[component]
+fn StepDot(n: u8, active: bool, done: bool, label: String) -> Element {
+    let (dot_class, text_class) = if active {
+        ("bg-ferrite-600 border-ferrite-500 text-white", "text-ferrite-400")
+    } else if done {
+        ("bg-green-500/20 border-green-500/40 text-green-400", "text-green-400")
+    } else {
+        ("bg-surface-800 border-surface-600 text-gray-500", "text-gray-500")
+    };
+    rsx! {
+        div { class: "flex flex-col items-center gap-1",
+            div {
+                class: "h-7 w-7 rounded-full border-2 {dot_class} flex items-center justify-center text-xs font-bold",
+                "{n}"
+            }
+            span { class: "text-[10px] font-medium {text_class} hidden sm:block", "{label}" }
+        }
+    }
+}

--- a/ferrite-dashboard/src/pages/campaign_new.rs
+++ b/ferrite-dashboard/src/pages/campaign_new.rs
@@ -290,11 +290,20 @@ fn FirmwareCard(
 #[component]
 fn StepDot(n: u8, active: bool, done: bool, label: String) -> Element {
     let (dot_class, text_class) = if active {
-        ("bg-ferrite-600 border-ferrite-500 text-white", "text-ferrite-400")
+        (
+            "bg-ferrite-600 border-ferrite-500 text-white",
+            "text-ferrite-400",
+        )
     } else if done {
-        ("bg-green-500/20 border-green-500/40 text-green-400", "text-green-400")
+        (
+            "bg-green-500/20 border-green-500/40 text-green-400",
+            "text-green-400",
+        )
     } else {
-        ("bg-surface-800 border-surface-600 text-gray-500", "text-gray-500")
+        (
+            "bg-surface-800 border-surface-600 text-gray-500",
+            "text-gray-500",
+        )
     };
     rsx! {
         div { class: "flex flex-col items-center gap-1",

--- a/ferrite-dashboard/src/pages/mod.rs
+++ b/ferrite-dashboard/src/pages/mod.rs
@@ -1,3 +1,5 @@
+pub mod campaign_detail;
+pub mod campaign_new;
 pub mod callback;
 pub mod compare;
 pub mod crashes;
@@ -5,12 +7,15 @@ pub mod dashboard;
 pub mod device_detail;
 pub mod devices;
 pub mod faults;
+pub mod ota;
 pub mod fleet;
 pub mod login;
 pub mod metrics;
 pub mod register;
 pub mod settings;
 
+pub use campaign_detail::CampaignDetailPage;
+pub use campaign_new::CampaignNewPage;
 pub use callback::CallbackPage;
 pub use compare::ComparePage;
 pub use crashes::{CrashDetailPage, CrashesPage};
@@ -21,5 +26,6 @@ pub use faults::FaultsPage;
 pub use fleet::FleetPage;
 pub use login::LoginPage;
 pub use metrics::MetricsPage;
+pub use ota::OtaPage;
 pub use register::RegisterPage;
 pub use settings::SettingsPage;

--- a/ferrite-dashboard/src/pages/mod.rs
+++ b/ferrite-dashboard/src/pages/mod.rs
@@ -1,22 +1,22 @@
+pub mod callback;
 pub mod campaign_detail;
 pub mod campaign_new;
-pub mod callback;
 pub mod compare;
 pub mod crashes;
 pub mod dashboard;
 pub mod device_detail;
 pub mod devices;
 pub mod faults;
-pub mod ota;
 pub mod fleet;
 pub mod login;
 pub mod metrics;
+pub mod ota;
 pub mod register;
 pub mod settings;
 
+pub use callback::CallbackPage;
 pub use campaign_detail::CampaignDetailPage;
 pub use campaign_new::CampaignNewPage;
-pub use callback::CallbackPage;
 pub use compare::ComparePage;
 pub use crashes::{CrashDetailPage, CrashesPage};
 pub use dashboard::DashboardPage;

--- a/ferrite-dashboard/src/pages/ota.rs
+++ b/ferrite-dashboard/src/pages/ota.rs
@@ -1,0 +1,278 @@
+use crate::api::types::*;
+use crate::auth::AuthState;
+use crate::components::{ErrorDisplay, Loading};
+use crate::Route;
+use dioxus::prelude::*;
+
+#[component]
+pub fn OtaPage() -> Element {
+    let auth_state = use_context::<Signal<AuthState>>();
+    let poll_tick = crate::hooks::use_poll_tick();
+    let reload = use_signal(|| 0u32);
+
+    let campaigns_resource = use_resource(move || async move {
+        let _tick = poll_tick();
+        let _r = reload();
+        let client = crate::api::client::authenticated_client(&auth_state());
+        client.list_campaigns().await
+    });
+
+    let firmware_resource = use_resource(move || async move {
+        let _r = reload();
+        let client = crate::api::client::authenticated_client(&auth_state());
+        client.list_firmware().await
+    });
+
+    let campaigns_binding = campaigns_resource.read();
+    let firmware_binding = firmware_resource.read();
+
+    let campaigns = match &*campaigns_binding {
+        None => return rsx! { Loading {} },
+        Some(Err(e)) => return rsx! { ErrorDisplay { message: e.to_string() } },
+        Some(Ok(c)) => c.clone(),
+    };
+
+    let firmware_list: Vec<FirmwareArtifact> = match &*firmware_binding {
+        Some(Ok(f)) => f.clone(),
+        _ => vec![],
+    };
+
+    let active_count = campaigns.iter().filter(|c| c.status == "active").count();
+    let completed_count = campaigns.iter().filter(|c| c.status == "completed").count();
+
+    rsx! {
+        div {
+            class: "p-6 lg:p-8 max-w-[1400px] mx-auto",
+
+            // Header
+            div {
+                class: "mb-6 animate-fade-in flex items-start justify-between",
+                div {
+                    h1 { class: "text-2xl font-semibold text-gray-100", "OTA Campaigns" }
+                    p { class: "mt-1 text-sm text-gray-500", "Manage firmware rollouts across your fleet" }
+                }
+                Link {
+                    to: Route::CampaignNew {},
+                    class: "inline-flex items-center gap-2 px-4 py-2 bg-ferrite-600 text-white rounded-lg hover:bg-ferrite-500 text-sm font-medium transition-colors",
+                    svg {
+                        class: "h-4 w-4",
+                        fill: "none",
+                        view_box: "0 0 24 24",
+                        stroke: "currentColor",
+                        stroke_width: "2",
+                        path { stroke_linecap: "round", stroke_linejoin: "round", d: "M12 4v16m8-8H4" }
+                    }
+                    "New Campaign"
+                }
+            }
+
+            // Summary cards
+            div {
+                class: "grid grid-cols-1 sm:grid-cols-3 gap-4 mb-6",
+                StatCard { label: "Total Campaigns", value: format!("{}", campaigns.len()), color: "ferrite" }
+                StatCard { label: "Active", value: format!("{}", active_count), color: "green" }
+                StatCard { label: "Completed", value: format!("{}", completed_count), color: "blue" }
+            }
+
+            // Campaigns table
+            div {
+                class: "bg-surface-900 rounded-xl border border-surface-700 mb-8",
+                div {
+                    class: "px-5 py-4 border-b border-surface-700 flex items-center justify-between",
+                    h2 { class: "text-sm font-semibold text-gray-200", "Campaigns" }
+                    p {
+                        class: "text-[10px] font-mono text-gray-600 uppercase tracking-wider",
+                        "{campaigns.len()} campaign(s)"
+                    }
+                }
+                if campaigns.is_empty() {
+                    div {
+                        class: "p-12 text-center",
+                        p { class: "text-sm text-gray-500 mb-4", "No campaigns yet" }
+                        Link {
+                            to: Route::CampaignNew {},
+                            class: "inline-flex items-center px-4 py-2 bg-ferrite-600 text-white rounded-lg hover:bg-ferrite-500 text-sm font-medium transition-colors",
+                            "Create your first campaign"
+                        }
+                    }
+                } else {
+                    div { class: "overflow-x-auto",
+                        table { class: "w-full text-sm",
+                            thead {
+                                tr { class: "border-b border-surface-700",
+                                    th { class: "px-5 py-3 text-left text-[10px] font-semibold text-gray-500 uppercase tracking-wider", "Name" }
+                                    th { class: "px-5 py-3 text-left text-[10px] font-semibold text-gray-500 uppercase tracking-wider", "Version" }
+                                    th { class: "px-5 py-3 text-left text-[10px] font-semibold text-gray-500 uppercase tracking-wider", "Strategy" }
+                                    th { class: "px-5 py-3 text-left text-[10px] font-semibold text-gray-500 uppercase tracking-wider", "Status" }
+                                    th { class: "px-5 py-3 text-left text-[10px] font-semibold text-gray-500 uppercase tracking-wider", "Actions" }
+                                }
+                            }
+                            tbody {
+                                for campaign in campaigns.iter() {
+                                    CampaignRow {
+                                        campaign: campaign.clone(),
+                                        auth_state,
+                                        reload,
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            // Firmware artifacts
+            div {
+                class: "bg-surface-900 rounded-xl border border-surface-700",
+                div {
+                    class: "px-5 py-4 border-b border-surface-700",
+                    h2 { class: "text-sm font-semibold text-gray-200", "Firmware Artifacts" }
+                    p { class: "mt-0.5 text-xs text-gray-500", "Upload new firmware via the ferrite-cli or API" }
+                }
+                if firmware_list.is_empty() {
+                    div {
+                        class: "p-8 text-center",
+                        p { class: "text-sm text-gray-500", "No firmware uploaded yet" }
+                        p { class: "text-xs text-gray-600 font-mono mt-2",
+                            "ferrite firmware upload --file firmware.bin --version 1.0.0"
+                        }
+                    }
+                } else {
+                    div { class: "overflow-x-auto",
+                        table { class: "w-full text-sm",
+                            thead {
+                                tr { class: "border-b border-surface-700",
+                                    th { class: "px-5 py-3 text-left text-[10px] font-semibold text-gray-500 uppercase tracking-wider", "Version" }
+                                    th { class: "px-5 py-3 text-left text-[10px] font-semibold text-gray-500 uppercase tracking-wider", "Build ID" }
+                                    th { class: "px-5 py-3 text-left text-[10px] font-semibold text-gray-500 uppercase tracking-wider", "Size" }
+                                    th { class: "px-5 py-3 text-left text-[10px] font-semibold text-gray-500 uppercase tracking-wider", "SHA-256" }
+                                    th { class: "px-5 py-3 text-left text-[10px] font-semibold text-gray-500 uppercase tracking-wider", "Uploaded" }
+                                }
+                            }
+                            tbody {
+                                for artifact in firmware_list.iter() {
+                                    tr { class: "border-b border-surface-800 hover:bg-surface-800/50 transition-colors",
+                                        td { class: "px-5 py-3 font-mono text-ferrite-400 font-semibold", "{artifact.version}" }
+                                        td { class: "px-5 py-3 font-mono text-gray-400 text-xs", "#{artifact.build_id}" }
+                                        td { class: "px-5 py-3 text-gray-300", "{artifact.size_display()}" }
+                                        td { class: "px-5 py-3 font-mono text-gray-500 text-xs truncate max-w-[140px]",
+                                            title: "{artifact.sha256}",
+                                            "{&artifact.sha256[..12]}…"
+                                        }
+                                        td { class: "px-5 py-3 text-gray-500 text-xs", "{fmt_date(&artifact.created_at)}" }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+// ── Sub-components ────────────────────────────────────────────────────────────
+
+#[component]
+fn CampaignRow(
+    campaign: OtaCampaign,
+    auth_state: Signal<AuthState>,
+    reload: Signal<u32>,
+) -> Element {
+    let id = campaign.id;
+
+    rsx! {
+        tr { class: "border-b border-surface-800 hover:bg-surface-800/50 transition-colors",
+            td { class: "px-5 py-3",
+                Link {
+                    to: Route::CampaignDetail { id: id.to_string() },
+                    class: "text-ferrite-400 hover:text-ferrite-300 font-medium transition-colors",
+                    "{campaign.name}"
+                }
+            }
+            td { class: "px-5 py-3 font-mono text-gray-300 text-xs", "{campaign.target_version}" }
+            td { class: "px-5 py-3",
+                span {
+                    class: "inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium border {campaign.strategy_color()}",
+                    "{campaign.strategy}"
+                }
+            }
+            td { class: "px-5 py-3",
+                span {
+                    class: "inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium border {campaign.status_color()}",
+                    "{campaign.status}"
+                }
+            }
+            td { class: "px-5 py-3",
+                div { class: "flex items-center gap-2",
+                    if campaign.can_activate() {
+                        button {
+                            class: "px-2.5 py-1 text-xs font-medium bg-green-500/10 border border-green-500/20 text-green-400 rounded-lg hover:bg-green-500/20 transition-colors",
+                            onclick: move |_| {
+                                let client = crate::api::client::authenticated_client(&auth_state());
+                                spawn(async move {
+                                    let _ = client.activate_campaign(id).await;
+                                    reload.set(reload() + 1);
+                                });
+                            },
+                            "Activate"
+                        }
+                    }
+                    if campaign.can_pause() {
+                        button {
+                            class: "px-2.5 py-1 text-xs font-medium bg-yellow-500/10 border border-yellow-500/20 text-yellow-400 rounded-lg hover:bg-yellow-500/20 transition-colors",
+                            onclick: move |_| {
+                                let client = crate::api::client::authenticated_client(&auth_state());
+                                spawn(async move {
+                                    let _ = client.pause_campaign(id).await;
+                                    reload.set(reload() + 1);
+                                });
+                            },
+                            "Pause"
+                        }
+                    }
+                    if campaign.can_rollback() {
+                        button {
+                            class: "px-2.5 py-1 text-xs font-medium bg-red-500/10 border border-red-500/20 text-red-400 rounded-lg hover:bg-red-500/20 transition-colors",
+                            onclick: move |_| {
+                                let client = crate::api::client::authenticated_client(&auth_state());
+                                spawn(async move {
+                                    let _ = client.rollback_campaign(id).await;
+                                    reload.set(reload() + 1);
+                                });
+                            },
+                            "Rollback"
+                        }
+                    }
+                    Link {
+                        to: Route::CampaignDetail { id: id.to_string() },
+                        class: "px-2.5 py-1 text-xs font-medium bg-surface-700 border border-surface-600 text-gray-400 rounded-lg hover:bg-surface-600 transition-colors",
+                        "Details"
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[component]
+fn StatCard(label: String, value: String, color: String) -> Element {
+    let accent = match color.as_str() {
+        "green" => "text-green-400",
+        "blue" => "text-blue-400",
+        "amber" => "text-amber-400",
+        "red" => "text-red-400",
+        _ => "text-ferrite-400",
+    };
+    rsx! {
+        div {
+            class: "bg-surface-900 rounded-xl border border-surface-700 p-4",
+            p { class: "text-[10px] font-semibold text-gray-500 uppercase tracking-wider mb-1", "{label}" }
+            p { class: "text-2xl font-bold font-mono {accent}", "{value}" }
+        }
+    }
+}
+
+fn fmt_date(s: &str) -> &str {
+    s.get(..10).unwrap_or(s)
+}


### PR DESCRIPTION
## Summary

- **OTA Campaigns list** (`/ota`): table with activate/pause/rollback actions per row, firmware artifacts section, summary stat cards (total/active/completed), auto-polls via `poll_tick`
- **Campaign detail** (`/ota/campaigns/:id`): live progress dashboard with per-device status table, progress bar (`installed / total`), action buttons (activate/pause/rollback), poll refresh
- **New campaign wizard** (`/ota/campaigns/new`): 2-step flow — step 1 picks firmware artifact with visual card selector; step 2 configures campaign name, rollout strategy (immediate/canary/scheduled), canary percent slider, and activate-now toggle
- **API layer**: `OtaCampaign`, `CampaignSummary`, `CampaignDevice`, `FirmwareArtifact` types; `list_campaigns`, `get_campaign`, `create_campaign`, `activate_campaign`, `pause_campaign`, `rollback_campaign`, `list_firmware`, `list_campaign_devices` on `ApiClient`
- **Navbar**: OTA sidebar link added between Fleet and Compare sections

Connects to Sprint 2b campaign engine endpoints (PR #61) and Sprint 2a firmware storage (PR #60).

## Test plan

- [ ] `cargo build -p ferrite-dashboard -j4` — clean build, zero warnings
- [ ] `dx serve` from `ferrite-dashboard/` — dev server starts
- [ ] Navigate to `/ota` — stat cards, campaigns table, firmware artifacts table render
- [ ] Create a campaign via wizard — firmware picker selects, config step validates, submits and redirects to detail page
- [ ] Detail page shows device progress rows and progress bar
- [ ] Activate/Pause/Rollback buttons update status (reload triggers)
- [ ] OTA sidebar link highlighted when on `/ota` routes

🤖 Generated with [Claude Code](https://claude.com/claude-code)