### PR TITLE
fix(docker): install dioxus-cli with --locked

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 RUN rustup target add wasm32-unknown-unknown
-RUN cargo install dioxus-cli@0.7.6
+RUN cargo install --locked dioxus-cli@0.7.6
 
 WORKDIR /app
 COPY . .


### PR DESCRIPTION
Unblocks the new deploy-image workflow: unlocked `cargo install dioxus-cli@0.7.6` now resolves kstring 2.0.4 (needs rustc 1.96) which rust:1.95-bookworm can't build. `--locked` restores the known-good dependency set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)